### PR TITLE
TBYRateProvider for Balancer Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # The Bloom Pool Protocol
-By Composable Corp
 
 ## The [`BloomPool`](src/BloomPool.sol) Contract
 
@@ -7,16 +6,17 @@ The BloomPool smart contract enables lenders and borrowers to deposit stablecoin
 tokenized treasuries. Borrowers need to be whitelisted and earn a spread compared to lenders.
 Borrowers are also the first in line to carry losses or gains from swapping to and from tokenized treasuries.
 
-Lender claims are fungible and tradeable as ERC20 tokens. Named `Term Bound Tokens` or TBT's for short.
+Lender claims are fungible and tradeable as ERC20 tokens. Named `Term Bound Yield` or TBY's for short.
 
 ### Parameters
 The constructor of the contract allows for easy deployment of new Billy pools.
-- `address underlyingToken`: Address of the stable coin to be used (the ERC20 lender token will copy its decimals)
+- `address underlyingToken`: Address of the stablecoin to be used (the ERC20 lender token will copy its decimals)
 - `address billToken`: Address of the treasury token
 - `IWhitelist whitelist`: IWhitelist of the whitelist to be used in the pool.
 - `address swapFacility`: Address of the swapFacility for pools to swap between
   underlying and tokenized T-Bills
-- `address treasury`: Address of the treasury recieving the management fees.
+- `address treasury`: Address of the treasury receiving the management fees.
+- `address emergencyHandler`: Address of the handler that will disperse funds in the event of an emergency 
 - `address lenderReturnBpsFeed`: The address for the pegged return feed that lenders to receive
   in basis points e.g. `10000` means lenders will receive 100% of their capital back (0% return) `10030` 
   would represent 103% or a 3% yield.
@@ -24,12 +24,12 @@ The constructor of the contract allows for easy deployment of new Billy pools.
   every $1 a borrower commits it'll match $35 of lender commitments 
 - `uint256 minBorrowerDeposit`: The minimum amount of tokens a borrower can Deposit to open up an order to be matched. 
 - `uint256 commitPhaseDuration`: How much time users should have to commit as borrowers/lenders from contract deployment.
+- `uint256 preHoldSwapTimeout`: How much time before the pool enters into emergency mode
 - `uint256 poolPhaseDuration`: How long the pool should hold the treasuries before swapping back and
   allowing people to withdraw, **highly recommended** to set this to the maturity length of the
   underlying treasuries as the pool has no liquidation mechanism.
-- `uint256 lenderReturnBps`: The fixed return lenders are to receive in basis points e.g. `10000`
-  means lenders will receive 100% of their capital back (0% return), `10030` would
-  represent 103% or a 3% yield.
+- `uint256 lenderReturnFee`: The fixed fee lenders pay to the treasury in basis points at the end of the pool duration.
+- `uint256 borrowerReturnFee`: The fixed fee borrowers pay to the treasury in basis points at the end of the pool duration.
 - `string memory name`: The ERC20-name the lender share token should have
 - `string memory symbol`: The ERC20-symbol the lender share token should have
 
@@ -79,7 +79,12 @@ The contract has several states and transitions between them based on the curren
 4. `State.Holding`: The pre-hold swap is completed, and the contract is holding the swapped tokens.
 5. `State.ReadyPostHoldSwap`: The contract is ready to initiate the post-hold swap after the pool phase ends.
 6. `State.PendingPostHoldSwap`: The post-hold swap is initiated and pending completion.
-7. `State.FinalWithdraw`: The post-hold swap is completed, and users can withdraw their share of the returned stablecoins.
+7. `State.EmergencyExit`: The pre-hold swap has exceeded the allotted time for swapping and swaps are not completed.
+8. `State.FinalWithdraw`: The post-hold swap is completed, and users can withdraw their share of the returned stablecoins.
+ 
+### Emergency Withdraw
+
+- `emergencyWithdrawTo(address)`: Allows the Emergency handler to withdraw the underlying and tokenized tokens in the event of the swap facility not completing swapping during the allotted amount of time, only then can the emergency handler unwind the process. 
 
 ## Integrations: Swap Facility & Whitelist
 
@@ -87,7 +92,7 @@ The contract has several states and transitions between them based on the curren
 
 The swap facility is required to swap the `UNDERLYING_TOKEN` to and from the `BILL_TOKEN`. The swap
 facility is completely trusted by the associated pool contract, the pool does not check or enforce
-any slippage on the swap result. Swaps do not have to occur atomically in one transaction, but can
+any slippage on the swap result. Swaps do not have to occur atomically in one transaction but can
 be settled at a later point in a separate call. Meaning any critical such as the aforementioned
 slippage checks must be performed by the swap facility.
 

--- a/src/TBYRateProvider.sol
+++ b/src/TBYRateProvider.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BUSL-1.1
+/*
+██████╗░██╗░░░░░░█████╗░░█████╗░███╗░░░███╗
+██╔══██╗██║░░░░░██╔══██╗██╔══██╗████╗░████║
+██████╦╝██║░░░░░██║░░██║██║░░██║██╔████╔██║
+██╔══██╗██║░░░░░██║░░██║██║░░██║██║╚██╔╝██║
+██████╦╝███████╗╚█████╔╝╚█████╔╝██║░╚═╝░██║
+╚═════╝░╚══════╝░╚════╝░░╚════╝░╚═╝░░░░░╚═╝
+*/
+
+pragma solidity 0.8.19;
+
+import {IRateProvider} from "./interfaces/IRateProvider.sol";
+import {BPSFeed} from "./BPSFeed.sol";
+
+contract TBYRateProvider is IRateProvider {
+    // IB01/USD Oracle returns an 8-decimal fixed point number
+    uint256 internal constant TBY_SCALING_FACTOR = 1e10;
+    BPSFeed public priceFeed;
+
+    constructor(BPSFeed _priceFeed) {
+        priceFeed = _priceFeed;
+    } 
+
+    /// @inheritdoc IRateProvider
+    function getRate() external view returns (uint256) {
+        return priceFeed.getWeightedRate() * TBY_SCALING_FACTOR;
+    }
+
+}

--- a/src/interfaces/IRateProvider.sol
+++ b/src/interfaces/IRateProvider.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: BUSL-1.1
+/*
+██████╗░██╗░░░░░░█████╗░░█████╗░███╗░░░███╗
+██╔══██╗██║░░░░░██╔══██╗██╔══██╗████╗░████║
+██████╦╝██║░░░░░██║░░██║██║░░██║██╔████╔██║
+██╔══██╗██║░░░░░██║░░██║██║░░██║██║╚██╔╝██║
+██████╦╝███████╗╚█████╔╝╚█████╔╝██║░╚═╝░██║
+╚═════╝░╚══════╝░╚════╝░░╚════╝░╚═╝░░░░░╚═╝
+*/
+
+pragma solidity ^0.8.0;
+
+interface IRateProvider {
+    /**
+     * @dev Returns an 18 decimal fixed point number that is the exchange rate of the token to some other underlying
+     * token. The meaning of this rate depends on the context.
+     * https://github.com/balancer/balancer-v2-monorepo/blob/master/pkg/interfaces/contracts/pool-utils/IRateProvider.sol
+     */
+    function getRate() external view returns (uint256);
+}

--- a/test/BPSFeed.t.sol
+++ b/test/BPSFeed.t.sol
@@ -119,9 +119,6 @@ contract BPSFeedTest is Test {
         feed.updateRate(rate3);
         skip(duration3);
 
-        emit log_named_uint("Rate", rate3);
-        emit log_named_uint("getRate", rateprovider.getRate());
-
         assertEq(rateprovider.getRate(), 100e18);
     }
 }

--- a/test/BPSFeed.t.sol
+++ b/test/BPSFeed.t.sol
@@ -13,6 +13,7 @@ pragma solidity 0.8.19;
 import {Test} from "forge-std/Test.sol";
 
 import {BPSFeed} from "src/BPSFeed.sol";
+import {TBYRateProvider} from "src/TBYRateProvider.sol";
 
 contract BPSFeedTest is Test {
     BPSFeed internal feed;
@@ -24,6 +25,8 @@ contract BPSFeedTest is Test {
     uint256 internal duration1 = 10 days;
     uint256 internal rate2 = 250;
     uint256 internal duration2 = 6 days;
+    uint256 internal rate3 = 100e8; // $100 IB01/USD via Chainlink Oracle 
+    uint256 internal duration3 = 5 days;
 
     function setUp() public {
         vm.prank(owner);
@@ -105,5 +108,20 @@ contract BPSFeedTest is Test {
         assertEq(feed.lastTimestamp(), lastTimestamp);
 
         vm.stopPrank();
+    }
+
+    function testTBYRateProviderGetRate() public {
+        assertEq(feed.currentRate(), 0);
+
+        vm.startPrank(owner);
+
+        TBYRateProvider rateprovider = new TBYRateProvider(feed);
+        feed.updateRate(rate3);
+        skip(duration3);
+
+        emit log_named_uint("Rate", rate3);
+        emit log_named_uint("getRate", rateprovider.getRate());
+
+        assertEq(rateprovider.getRate(), 100e18);
     }
 }


### PR DESCRIPTION
Adding `TBYRateProvider` to allow for proper integration of the BPSFeed in Balancer Pools.

Contracts Added:
- `IRateProvider`
    - Balancers RateProvider Interface
- `TBYRateProvider`
    - Returns an 18-decimal fixed point representation of TBYs `weightedRate`
 
Contracts Edited:
- `BPSFeed.t.sol`
   - Tests added for `TBYRateProvider`'s `getRate` function