### PR TITLE
Updated Registry & Tests Added

### DIFF
--- a/src/BPSFeed.sol
+++ b/src/BPSFeed.sol
@@ -21,7 +21,13 @@ contract BPSFeed is IBPSFeed, Owned {
     uint256 internal _totalRate;
     uint256 internal _totalDuration;
 
-    constructor() Owned(msg.sender) {}
+    // ================== Constants ==================
+    uint256 internal constant INITIAL_RATE = 1e4;
+    uint256 internal constant MAX_RATE = 1.5e4;
+
+    constructor() Owned(msg.sender) {
+        currentRate = INITIAL_RATE;
+    }
 
     /// @inheritdoc IBPSFeed
     function getWeightedRate() external view returns (uint256) {
@@ -35,12 +41,18 @@ contract BPSFeed is IBPSFeed, Owned {
 
     /// @inheritdoc IBPSFeed
     function updateRate(uint256 _rate) external onlyOwner {
+        if (_rate < INITIAL_RATE || _rate > MAX_RATE) {
+            revert InvalidRate();
+        }
         if (lastTimestamp > 0) {
             uint256 lastRateDuration = block.timestamp - lastTimestamp;
             _totalRate += currentRate * lastRateDuration;
             _totalDuration += lastRateDuration;
         }
+
         currentRate = _rate;
         lastTimestamp = block.timestamp;
+
+        emit UpdateRate(currentRate);
     }
 }

--- a/src/helpers/ExchangeRateRegistry.sol
+++ b/src/helpers/ExchangeRateRegistry.sol
@@ -28,7 +28,6 @@ contract ExchangeRateRegistry is Ownable {
     using EnumerableSet for EnumerableSet.AddressSet;
 
     uint256 public constant BASE_RATE = 1e18;
-    uint256 public constant ONE_YEAR = 360 days;
     uint256 public constant SCALER = 1e14;
 
     struct TokenInfo {
@@ -190,6 +189,13 @@ contract ExchangeRateRegistry is Ownable {
     }
 
     /**
+     * @notice Return true if the registry has been initialized
+     */
+    function isRegistryInitialized() external view returns (bool) {
+        return _initialized;
+    }
+
+    /**
      * @notice Update the exchange rate for the given token
      * @param token The token address
      */
@@ -255,10 +261,10 @@ contract ExchangeRateRegistry is Ownable {
             timeElapsed = duration;
         }
         uint256 adjustedLenderFee = (lenderFee * SCALER);
+        
+        uint256 delta = ((rate * (BASE_RATE - adjustedLenderFee) / 1e18) * timeElapsed) / 
+            duration;
 
-        uint256 delta = (rate * (BASE_RATE - adjustedLenderFee) * timeElapsed) /
-            ONE_YEAR;
-
-        return BASE_RATE + (delta * BASE_RATE);
+        return BASE_RATE + ((delta * BASE_RATE) / 1e18);
     }
 }

--- a/src/interfaces/IBPSFeed.sol
+++ b/src/interfaces/IBPSFeed.sol
@@ -11,6 +11,10 @@
 pragma solidity ^0.8.0;
 
 interface IBPSFeed {
+    error InvalidRate();
+
+    event UpdateRate(uint256 currentRate);
+
     /// @notice Returns weighted rate
     function getWeightedRate() external view returns (uint256);
 

--- a/test/ExchangeRateRegistry.t.sol
+++ b/test/ExchangeRateRegistry.t.sol
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: BUSL-1.1
+/*
+██████╗░██╗░░░░░░█████╗░░█████╗░███╗░░░███╗
+██╔══██╗██║░░░░░██╔══██╗██╔══██╗████╗░████║
+██████╦╝██║░░░░░██║░░██║██║░░██║██╔████╔██║
+██╔══██╗██║░░░░░██║░░██║██║░░██║██║╚██╔╝██║
+██████╦╝███████╗╚█████╔╝╚█████╔╝██║░╚═╝░██║
+╚═════╝░╚══════╝░╚════╝░░╚════╝░╚═╝░░░░░╚═╝
+*/
+
+pragma solidity 0.8.19;
+
+import {Test} from "forge-std/Test.sol";
+
+import {BloomPool, State, AssetCommitment} from "src/BloomPool.sol";
+import {ExchangeRateRegistry} from "src/helpers/ExchangeRateRegistry.sol";
+import {IBloomPool} from "src/interfaces/IBloomPool.sol";
+import {IWhitelist} from "src/interfaces/IWhitelist.sol";
+import {IBPSFeed} from "src/interfaces/IBPSFeed.sol";
+import {MockERC20} from "./mock/MockERC20.sol";
+import {MockWhitelist} from "./mock/MockWhitelist.sol";
+import {MockSwapFacility} from "./mock/MockSwapFacility.sol";
+import {MockBPSFeed} from "./mock/MockBPSFeed.sol";
+
+contract ExchangeRateRegistryTest is Test {
+    BloomPool internal pool;
+    MockERC20 internal stableToken;
+    MockERC20 internal billyToken;
+    MockWhitelist internal whitelist;
+    MockSwapFacility internal swap;
+
+    address internal treasury = makeAddr("treasury");
+    address internal registryOwner = makeAddr("owner");
+
+    MockBPSFeed internal feed;
+    ExchangeRateRegistry internal registry;
+
+    uint256 internal constant ORACLE_RATE = 200;
+    uint256 internal constant BPS = 1e4;
+    uint256 internal constant LENDER_RETURN_FEE = 1000;
+    uint256 internal constant SCALER = 1e14;
+    uint256 internal constant COMMIT_PHASE = 3 days;
+    uint256 internal constant POOL_DURATION = 360 days;
+
+    uint256 internal constant STARTING_EXCHANGE_RATE = 1e18;
+
+    struct TokenInfo {
+        bool registered;
+        bool active;
+        address pool;
+        uint256 createdAt;
+        uint256 exchangeRate;
+    }
+
+    function setUp() public {
+        stableToken = new MockERC20(6);
+        billyToken = new MockERC20(18);
+        whitelist = new MockWhitelist();
+        swap = new MockSwapFacility(stableToken, billyToken);
+        feed = new MockBPSFeed();
+
+        feed.setRate(ORACLE_RATE);
+
+        pool = new BloomPool({
+            underlyingToken: address(stableToken),
+            billToken: address(billyToken),
+            whitelist: IWhitelist(address(whitelist)),
+            swapFacility: address(swap),
+            treasury: treasury,
+            leverageBps: 4 * BPS,
+            emergencyHandler: address(0),
+            minBorrowDeposit: 100e18,
+            commitPhaseDuration: COMMIT_PHASE,
+            preHoldSwapTimeout: 7 days,
+            poolPhaseDuration: POOL_DURATION,
+            lenderReturnBpsFeed: address(feed),
+            lenderReturnFee: LENDER_RETURN_FEE,
+            borrowerReturnFee: 3000,
+            name: "Term Bound Token 6 month 2023-06-1",
+            symbol: "TBT-1"
+        });
+
+        registry = new ExchangeRateRegistry();
+    }
+
+    function test_InitializeRegistry() public {
+        assertEq(registry.isRegistryInitialized(), false);
+        registry.initialize(registryOwner);
+        assertEq(registry.isRegistryInitialized(), true);
+    }
+
+    function test_ExpectRevertWhenDoubleInitializing() public {
+        registry.initialize(registryOwner);
+        assertEq(registry.isRegistryInitialized(), true);
+        vm.prank(registryOwner);
+        vm.expectRevert("ExchangeRateRegistry: contract is already initialized");
+        registry.initialize(registryOwner);
+    }
+
+    function test_ExpectRevertWhenRandoInitializes() public {
+        registry.initialize(registryOwner);
+        assertEq(registry.isRegistryInitialized(), true);
+        
+        address rando = makeAddr("rando");        
+        
+        vm.expectRevert("Ownable: caller is not the owner");
+        registry.initialize(registryOwner);
+    }
+
+    function test_ExpectRevertWhenOwnerIsZero() public {
+        assertEq(registry.isRegistryInitialized(), false);
+
+        vm.expectRevert("ExchangeRateRegistry: owner is the zero address");
+        registry.initialize(address(0));
+    }
+
+    function test_GetExchangeRate() public {
+        registry.initialize(registryOwner);
+
+        vm.prank(registryOwner);
+        skip(COMMIT_PHASE);
+        
+        registry.registerToken(address(billyToken), address(pool));
+        assertEq(registry.getExchangeRate(address(billyToken)), STARTING_EXCHANGE_RATE);
+
+        uint256 testingIntervals = 5;
+
+        for (uint256 i=1; i <= testingIntervals; i++) {
+            uint256 timePerInterval = POOL_DURATION / testingIntervals;
+            skip(timePerInterval);
+
+            uint256 valueAccrued = ((ORACLE_RATE * SCALER) / testingIntervals) * i;
+            uint256 lenderShare = valueAccrued * (LENDER_RETURN_FEE * SCALER) / 1e18;
+            uint256 expectedRate = STARTING_EXCHANGE_RATE + valueAccrued - lenderShare;
+
+            assertEq(registry.getExchangeRate(address(billyToken)), expectedRate);
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes the `ExchangeRateRegistry` that will be used for calculating exchange rates for TBYs in DeFi liquidity pools. 

Changes Made:
- `BPSFeed`: Added changes from the main branch to keep `helpers` branch current.
- `IBPSFeed`: Added changes from the main branch to keep `helpers` branch current.
- `ExchangeRateRegistry`: 
    - Adjusted the delta calculation to use proper decimal scaling and use the duration local variable instead of `ONE_YEAR`. This is to make sure that the end time of maturity is consistent with any future deployed TBY.
    - Adjusted the return calculation to use proper decimal scaling.
    - Added `isRegistryInitialized` function to allow users to check if the registry has been initialized.
    - Removed `ONE_YEAR` constant.
- `ExchangeRateRegistry.t.sol`: Tests for `ExchangeRateRegistry`.