### PR TITLE
Simplified Math and Rate Format Update

### DIFF
--- a/src/helpers/ExchangeRateRegistry.sol
+++ b/src/helpers/ExchangeRateRegistry.sol
@@ -27,6 +27,7 @@ import "../interfaces/IBloomPool.sol";
 contract ExchangeRateRegistry is Ownable {
     using EnumerableSet for EnumerableSet.AddressSet;
 
+    uint256 public constant INITIAL_FEED_RATE = 1e4;
     uint256 public constant BASE_RATE = 1e18;
     uint256 public constant SCALER = 1e14;
 
@@ -255,7 +256,7 @@ contract ExchangeRateRegistry is Ownable {
         uint256 duration = pool.POOL_PHASE_DURATION();
         IBPSFeed bpsFeed = IBPSFeed(pool.LENDER_RETURN_BPS_FEED());
 
-        uint256 rate = (bpsFeed.getWeightedRate() * SCALER);
+        uint256 rate = (bpsFeed.getWeightedRate() - INITIAL_FEED_RATE) * SCALER;
         uint256 timeElapsed = block.timestamp - info.createdAt;
         if (timeElapsed > duration) {
             timeElapsed = duration;
@@ -265,6 +266,6 @@ contract ExchangeRateRegistry is Ownable {
         uint256 delta = ((rate * (BASE_RATE - adjustedLenderFee) / 1e18) * timeElapsed) / 
             duration;
 
-        return BASE_RATE + ((delta * BASE_RATE) / 1e18);
+        return BASE_RATE + delta;
     }
 }

--- a/test/ExchangeRateRegistry.t.sol
+++ b/test/ExchangeRateRegistry.t.sol
@@ -35,7 +35,7 @@ contract ExchangeRateRegistryTest is Test {
     MockBPSFeed internal feed;
     ExchangeRateRegistry internal registry;
 
-    uint256 internal constant ORACLE_RATE = 200;
+    uint256 internal constant ORACLE_RATE = 10200;
     uint256 internal constant BPS = 1e4;
     uint256 internal constant LENDER_RETURN_FEE = 1000;
     uint256 internal constant SCALER = 1e14;
@@ -128,8 +128,8 @@ contract ExchangeRateRegistryTest is Test {
         for (uint256 i=1; i <= testingIntervals; i++) {
             uint256 timePerInterval = POOL_DURATION / testingIntervals;
             skip(timePerInterval);
-
-            uint256 valueAccrued = ((ORACLE_RATE * SCALER) / testingIntervals) * i;
+            
+            uint256 valueAccrued = (((ORACLE_RATE - 1e4) * SCALER) / testingIntervals) * i;
             uint256 lenderShare = valueAccrued * (LENDER_RETURN_FEE * SCALER) / 1e18;
             uint256 expectedRate = STARTING_EXCHANGE_RATE + valueAccrued - lenderShare;
 


### PR DESCRIPTION
This PR makes small adjustments in the math in calculating TBY exchange rates for DeFi Liquidity Pools.

Files Changed:
- `ExchangeRateRegistry`: 
    - `INITIAL_FEED_RATE` added to adjust oracle rate due to new input style.
    - Oracle rate scaling edited to adjust to the new style.
    - Return value math simplified.
- `ExchangeRateRegistry.t.sol`: Switched testing rate from `200` format to `10200` format to match main branch tests.