### PR TITLE
Rate Provider Updates

### DIFF
--- a/src/helpers/TBYRateProvider.sol
+++ b/src/helpers/TBYRateProvider.sol
@@ -43,13 +43,6 @@ contract TBYRateProvider is IRateProvider {
     }
 
     /**
-     * @return address of TBY
-     */
-    function getTBYAddress() public view returns (address) {
-        return tby;
-    }
-
-    /**
      * @return value of TBY in terms of USD returns an 18 decimal number
      */
     function getRate() public view override returns (uint256) {

--- a/test/ExchangeRateRegistry.t.sol
+++ b/test/ExchangeRateRegistry.t.sol
@@ -102,6 +102,7 @@ contract ExchangeRateRegistryTest is Test {
         assertEq(registry.isRegistryInitialized(), true);
         
         address rando = makeAddr("rando");        
+        vm.prank(rando);
         
         vm.expectRevert("Ownable: caller is not the owner");
         registry.initialize(registryOwner);


### PR DESCRIPTION
This PR is the final edits to complete the `TBYRateProvider` for Balancer Stable Pool integration.

Files Changed:
- `ExchangeRateRegistry`: 
    - `ONE_YEAR` storage variable added back into the delta math.
    - Unnecessary functions and struct parameter removed
        - Removed `exchangeRate` from `TokenInfo` struct
        - Removed `updateExchangeRate`, `updateExchangeRateForAll` and all corresponding internal functions.
        - Removed `ExchangeRateUpdated` event
        - Removed `getRecentRate`
-  `ExchangeRateRegistry.t.sol`:  Fixed a test to include the right address performing the transaction.
- `TBYRateProvider`: Removed redundant getter, `getTBYAddress`.