### PR TITLE
Bug fix: Arithmetic Underflow (Bloom Pool)

### DIFF
--- a/src/BloomPool.sol
+++ b/src/BloomPool.sol
@@ -30,7 +30,9 @@ contract BloomPool is IBloomPool, ISwapRecipient, ERC20 {
     using SafeCastLib for uint256;
 
     uint256 internal constant BPS = 1e4;
-
+    uint256 internal constant ONE_YEAR = 360 days;
+    event CodeRech(uint256 num);
+    event Value(string s, uint256 v);
     // =============== Core Parameters ===============
 
     address public immutable UNDERLYING_TOKEN;
@@ -209,16 +211,24 @@ contract BloomPool is IBloomPool, ISwapRecipient, ERC20 {
         if (currentState == State.PendingPostHoldSwap) {
             if (outToken != UNDERLYING_TOKEN) revert InvalidOutToken(outToken);
             uint256 totalMatched = totalMatchAmount();
+            emit Value("macthed",totalMatched);
+
+            uint256 yieldEarned = totalMatched * IBPSFeed(LENDER_RETURN_BPS_FEED).getWeightedRate() * POOL_PHASE_DURATION / ONE_YEAR / BPS;
+            
+            emit Value("yield",yieldEarned);
 
             // Lenders get paid first, borrowers carry any shortfalls/excesses due to slippage.
             uint256 lenderReturn = Math.min(
-                totalMatched * IBPSFeed(LENDER_RETURN_BPS_FEED).getWeightedRate() * POOL_PHASE_DURATION / 360 days / BPS,
+                totalMatched + yieldEarned,
                 outAmount
             );
+            emit Value("Return", lenderReturn);
             uint256 borrowerReturn = outAmount - lenderReturn;
-
+            emit CodeRech(1);
             uint256 lenderReturnFee = (lenderReturn - totalMatched) * LENDER_RETURN_FEE / BPS;
+            emit Value("lrt", lenderReturnFee);
             uint256 borrowerReturnFee = borrowerReturn * BORROWER_RETURN_FEE / BPS;
+            emit Value("brt", borrowerReturnFee);
 
             borrowerDistribution = (borrowerReturn - borrowerReturnFee).toUint128();
             totalBorrowerShares = uint256(totalMatched * BPS / LEVERAGE_BPS).toUint128();
@@ -229,6 +239,7 @@ contract BloomPool is IBloomPool, ISwapRecipient, ERC20 {
             UNDERLYING_TOKEN.safeTransfer(TREASURY, lenderReturnFee + borrowerReturnFee);
 
             emit ExplictStateTransition(State.PendingPostHoldSwap, setState = State.FinalWithdraw);
+            emit CodeRech(2);
             return;
         }
         revert InvalidState(currentState);

--- a/src/BloomPool.sol
+++ b/src/BloomPool.sol
@@ -211,9 +211,8 @@ contract BloomPool is IBloomPool, ISwapRecipient, ERC20 {
             if (outToken != UNDERLYING_TOKEN) revert InvalidOutToken(outToken);
             uint256 totalMatched = totalMatchAmount();
 
-            uint256 yieldEarned = totalMatched * IBPSFeed(LENDER_RETURN_BPS_FEED).getWeightedRate() * POOL_PHASE_DURATION / ONE_YEAR / BPS;
-            
             // Lenders get paid first, borrowers carry any shortfalls/excesses due to slippage.
+            uint256 yieldEarned = totalMatched * IBPSFeed(LENDER_RETURN_BPS_FEED).getWeightedRate() * POOL_PHASE_DURATION / ONE_YEAR / BPS;
             uint256 lenderReturn = Math.min(
                 totalMatched + yieldEarned,
                 outAmount

--- a/test/BillyPool.t.sol
+++ b/test/BillyPool.t.sol
@@ -59,7 +59,7 @@ contract BloomPoolTest is Test {
         swap = new MockSwapFacility(stableToken, billyToken);
         feed = new MockBPSFeed();
 
-        feed.setRate((BPS + 30) * 12);
+        feed.setRate(1e4);
 
         pool = new BloomPool({
             underlyingToken: address(stableToken),
@@ -352,9 +352,10 @@ contract BloomPoolTest is Test {
             assertEq(borrowerShares, borrowAmount);
             assertEq(lenderShares, lenderAmount);
             totalAmount = billsReceived * billPrice / 1e18;
-            lenderReceived = lenderAmount * IBPSFeed(pool.LENDER_RETURN_BPS_FEED()).getWeightedRate() / 12 / BPS;
-            borrowerReceived = totalAmount - lenderReceived;
             uint256 totalMatchAmount = pool.totalMatchAmount();
+            uint256 lenderYield = totalMatchAmount * IBPSFeed(pool.LENDER_RETURN_BPS_FEED()).getWeightedRate() * 30 / 360 / BPS;
+            lenderReceived = totalMatchAmount + lenderYield;
+            borrowerReceived = totalAmount - lenderReceived;
             uint256 lenderFee = (lenderReceived - totalMatchAmount) * pool.LENDER_RETURN_FEE() / BPS;
             uint256 borrowerFee = borrowerReceived * pool.BORROWER_RETURN_FEE() / BPS;
             lenderReceived -= lenderFee;

--- a/test/BillyPool.t.sol
+++ b/test/BillyPool.t.sol
@@ -59,7 +59,7 @@ contract BloomPoolTest is Test {
         swap = new MockSwapFacility(stableToken, billyToken);
         feed = new MockBPSFeed();
 
-        feed.setRate(1e4);
+        feed.setRate(1.25e4);
 
         pool = new BloomPool({
             underlyingToken: address(stableToken),

--- a/test/mock/MockOracle.sol
+++ b/test/mock/MockOracle.sol
@@ -14,8 +14,11 @@ import {IOracle} from "src/interfaces/IOracle.sol";
 
 contract MockOracle is IOracle {
     int256 public latestAnswer;
+    uint8 public decimals;
 
-    uint8 public constant decimals = 8;
+    constructor(uint8 _decimals) {
+       decimals = _decimals;
+    }
 
     function setAnswer(int256 _answer) external {
         latestAnswer = _answer;


### PR DESCRIPTION
This pull request fixes the current bug within `BloomPool` where `completeSwap` reverts during the `PendingPostHoldSwap` period due to arithmetic underflow when calculating the `lenderReturnFee`.

**Files Changed:**
BloomPool.sol: 
- Removed hardcoded values and replaced with a constant variable `ONE_YEAR`.
- Fixed the `lenderReturn` calculation.

BillyPool.t.sol:
- Changed the rate of the `BPSFeed` to be in line with the updated contract rules.
- Fixed testing math

MockOracle.sol:
- Removed hardcoded values to allow constructor arguments to set `decimals`