### PR TITLE
Update to `preHoldSwapTimeout` to be `swapTimeout`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The constructor of the contract allows for easy deployment of new Billy pools.
   every $1 a borrower commits it'll match $35 of lender commitments 
 - `uint256 minBorrowerDeposit`: The minimum amount of tokens a borrower can Deposit to open up an order to be matched. 
 - `uint256 commitPhaseDuration`: How much time users should have to commit as borrowers/lenders from contract deployment.
-- `uint256 preHoldSwapTimeout`: How much time before the pool enters into emergency mode
+- `uint256 swapTimeout`: How much time before the pool enters into emergency mode
 - `uint256 poolPhaseDuration`: How long the pool should hold the treasuries before swapping back and
   allowing people to withdraw, **highly recommended** to set this to the maturity length of the
   underlying treasuries as the pool has no liquidation mechanism.

--- a/script/deploy.main.sol
+++ b/script/deploy.main.sol
@@ -52,7 +52,7 @@ contract Deploy is Test, Script {
     uint256 internal constant BPS = 1e4;
     uint256 internal constant commitPhaseDuration = 3 days;
     uint256 internal constant poolPhaseDuration = 180 days;
-    uint256 internal constant preHoldSwapTimeout = 7 days;
+    uint256 internal constant swapTimeout = 7 days;
 
     // True if we want to deploy a factory. False if we want to use an existing one
     bool internal constant DEPLOY_FACTORY = true;
@@ -88,7 +88,7 @@ contract Deploy is Test, Script {
             50e4,
             10.0e6,
             commitPhaseDuration,
-            preHoldSwapTimeout,
+            swapTimeout,
             poolPhaseDuration,
             300, // 3%
             0 // 0%
@@ -186,7 +186,7 @@ contract Deploy is Test, Script {
     //         50e4,
     //         10.0e6,
     //         commitPhaseDuration,
-    //         preHoldSwapTimeout,
+    //         swapTimeout,
     //         poolPhaseDuration,
     //         300, // 3%
     //         0, // 0%

--- a/script/deploy.main.test.sol
+++ b/script/deploy.main.test.sol
@@ -52,7 +52,7 @@ contract Deploy is Test, Script {
     uint256 internal constant BPS = 1e4;
     uint256 internal constant commitPhaseDuration = 3 days;
     uint256 internal constant poolPhaseDuration = 180 days;
-    uint256 internal constant preHoldSwapTimeout = 7 days;
+    uint256 internal constant swapTimeout = 7 days;
 
     // True if we want to deploy a factory. False if we want to use an existing one
     bool internal constant DEPLOY_FACTORY = true;
@@ -88,7 +88,7 @@ contract Deploy is Test, Script {
             50e4,
             10.0e6,
             commitPhaseDuration,
-            preHoldSwapTimeout,
+            swapTimeout,
             poolPhaseDuration,
             300, // 3%
             0 // 0%
@@ -191,7 +191,7 @@ contract Deploy is Test, Script {
             50e4,
             10.0e6,
             commitPhaseDuration,
-            preHoldSwapTimeout,
+            swapTimeout,
             poolPhaseDuration,
             300, // 3%
             0, // 0%

--- a/script/deploy.sepolia.sol
+++ b/script/deploy.sepolia.sol
@@ -58,7 +58,7 @@ contract Deploy is Test, Script {
     uint256 internal constant BPS = 1e4;
     uint256 internal constant commitPhaseDuration = 10 days;
     uint256 internal constant poolPhaseDuration = 2 days;
-    uint256 internal constant preHoldSwapTimeout = 1 days;
+    uint256 internal constant swapTimeout = 1 days;
     // True if we want to deploy a factory. False if we want to use an existing one
     bool internal constant DEPLOY_FACTORY = true;
     bool internal constant DEPLOY_EXCHANGE_RATE_REGISTRY = true;
@@ -94,7 +94,7 @@ contract Deploy is Test, Script {
             50e4,
             10.0e6,
             commitPhaseDuration,
-            preHoldSwapTimeout,
+            swapTimeout,
             poolPhaseDuration,
             300, // 3%
             0 // 0%
@@ -192,7 +192,7 @@ contract Deploy is Test, Script {
     //         50e4,
     //         10.0e6,
     //         commitPhaseDuration,
-    //         preHoldSwapTimeout,
+    //         swapTimeout,
     //         poolPhaseDuration,
     //         300, // 3%
     //         0, // 0%

--- a/src/BloomFactory.sol
+++ b/src/BloomFactory.sol
@@ -77,7 +77,7 @@ contract BloomFactory is IBloomFactory, Ownable2Step {
             poolParams.leverageBps,
             poolParams.minBorrowDeposit,
             poolParams.commitPhaseDuration,
-            poolParams.preHoldSwapTimeout,
+            poolParams.swapTimeout,
             poolParams.poolPhaseDuration,
             poolParams.lenderReturnFee,
             poolParams.borrowerReturnFee,

--- a/src/interfaces/IBloomFactory.sol
+++ b/src/interfaces/IBloomFactory.sol
@@ -26,7 +26,7 @@ interface IBloomFactory {
         uint256 leverageBps;
         uint256 minBorrowDeposit;
         uint256 commitPhaseDuration;
-        uint256 preHoldSwapTimeout;
+        uint256 swapTimeout;
         uint256 poolPhaseDuration;
         uint256 lenderReturnFee;
         uint256 borrowerReturnFee;

--- a/src/interfaces/IBloomPool.sol
+++ b/src/interfaces/IBloomPool.sol
@@ -112,6 +112,7 @@ interface IBloomPool {
     function MIN_BORROW_DEPOSIT() external view returns (uint256);
     function COMMIT_PHASE_END() external view returns (uint256);
     function PRE_HOLD_SWAP_TIMEOUT_END() external view returns (uint256);
+    function POST_HOLD_SWAP_TIMEOUT_END() external view returns (uint256);
     function POOL_PHASE_END() external view returns (uint256);
     function POOL_PHASE_DURATION() external view returns (uint256);
     function LENDER_RETURN_FEE() external view returns (uint256);

--- a/test/BloomFactory.t.sol
+++ b/test/BloomFactory.t.sol
@@ -54,7 +54,7 @@ contract BloomFactoryTest is Test {
             leverageBps: 0,
             minBorrowDeposit: 100e18,
             commitPhaseDuration: 3 days,
-            preHoldSwapTimeout: 7 days,
+            swapTimeout: 7 days,
             poolPhaseDuration: 180 days,
             lenderReturnFee: 1000,
             borrowerReturnFee: 300

--- a/test/ExchangeRateRegistry.t.sol
+++ b/test/ExchangeRateRegistry.t.sol
@@ -72,7 +72,7 @@ contract ExchangeRateRegistryTest is Test {
             emergencyHandler: address(0),
             minBorrowDeposit: 100e18,
             commitPhaseDuration: COMMIT_PHASE,
-            preHoldSwapTimeout: 7 days,
+            swapTimeout: 7 days,
             poolPhaseDuration: POOL_DURATION,
             lenderReturnBpsFeed: address(feed),
             lenderReturnFee: LENDER_RETURN_FEE,


### PR DESCRIPTION
This PR changes `preHoldSwapTimeout` to be `swapTimeout` such that it's inclusive of idle swaps on both states. This fix addresses all deploy scripts, `BloomPool`, `BloomPool.t.sol`, and `IBloomPool`. 