### PR TITLE
EmergencyHandler

### DIFF
--- a/src/BloomPool.sol
+++ b/src/BloomPool.sol
@@ -288,25 +288,25 @@ contract BloomPool is IBloomPool, ISwapRecipient, ERC20 {
         uint256 underlyingBalance = UNDERLYING_TOKEN.balanceOf(address(this));
         uint256 billBalance = BILL_TOKEN.balanceOf(address(this));
 
+        IOracle underlyingOracle = IOracle(ISwapFacility(SWAP_FACILITY).billyTokenOracle());
+        IOracle billOracle = IOracle(ISwapFacility(SWAP_FACILITY).underlyingTokenOracle());
+
         if (underlyingBalance > 0) {
-            IOracle oracle = IOracle(ISwapFacility(SWAP_FACILITY).underlyingTokenOracle());
             UNDERLYING_TOKEN.safeTransferAll(EMERGENCY_HANDLER);
-            IEmergencyHandler(EMERGENCY_HANDLER).registerPool(
-                oracle,
-                UNDERLYING_TOKEN
-            );
             emit EmergencyWithdrawExecuted(address(this), EMERGENCY_HANDLER, underlyingBalance);
         }
         
         if (billBalance > 0) {
-            IOracle oracle = IOracle(ISwapFacility(SWAP_FACILITY).billyTokenOracle());
             BILL_TOKEN.safeTransferAll(EMERGENCY_HANDLER);
-            IEmergencyHandler(EMERGENCY_HANDLER).registerPool(
-                oracle,
-                BILL_TOKEN
-            );
             emit EmergencyWithdrawExecuted(address(this), EMERGENCY_HANDLER, billBalance);
         }
+
+        IEmergencyHandler(EMERGENCY_HANDLER).registerPool(
+            UNDERLYING_TOKEN,
+            BILL_TOKEN,
+            underlyingOracle,
+            billOracle
+        );
     }
 
     function executeEmergencyBurn(

--- a/src/BloomPool.sol
+++ b/src/BloomPool.sol
@@ -285,7 +285,6 @@ contract BloomPool is IBloomPool, ISwapRecipient, ERC20 {
     // ========= Emergency Withdraw Methods ==========
 
     function emergencyWithdraw() external onlyState(State.EmergencyExit) {
-        emit EmergencyWithdraw(EMERGENCY_HANDLER);
         uint256 underlyingBalance = UNDERLYING_TOKEN.balanceOf(address(this));
         uint256 billBalance = BILL_TOKEN.balanceOf(address(this));
 
@@ -296,6 +295,7 @@ contract BloomPool is IBloomPool, ISwapRecipient, ERC20 {
                 oracle,
                 UNDERLYING_TOKEN
             );
+            emit EmergencyWithdrawExecuted(address(this), EMERGENCY_HANDLER, underlyingBalance);
         }
         
         if (billBalance > 0) {
@@ -305,6 +305,7 @@ contract BloomPool is IBloomPool, ISwapRecipient, ERC20 {
                 oracle,
                 BILL_TOKEN
             );
+            emit EmergencyWithdrawExecuted(address(this), EMERGENCY_HANDLER, billBalance);
         }
     }
 

--- a/src/BloomPool.sol
+++ b/src/BloomPool.sol
@@ -58,6 +58,7 @@ contract BloomPool is IBloomPool, ISwapRecipient, ERC20 {
     Commitments internal borrowers;
     Commitments internal lenders;
     State internal setState = State.Commit;
+    State internal stateBeforeEmergency;
     uint128 internal borrowerDistribution;
     uint128 internal totalBorrowerShares;
     uint128 internal lenderDistribution;
@@ -221,13 +222,7 @@ contract BloomPool is IBloomPool, ISwapRecipient, ERC20 {
             uint256 totalMatched = totalMatchAmount();
 
             // Lenders get paid first, borrowers carry any shortfalls/excesses due to slippage.
-            uint256 rateAppreciation = IBPSFeed(LENDER_RETURN_BPS_FEED).getWeightedRate() - BPS;
-            uint256 yieldEarned = totalMatched * rateAppreciation * POOL_PHASE_DURATION / ONE_YEAR / BPS;
-
-            uint256 lenderReturn = Math.min(
-                totalMatched + yieldEarned,
-                outAmount
-            );
+            uint256 lenderReturn = _calculateLenderReturn(totalMatched, outAmount);
 
             uint256 borrowerReturn = outAmount - lenderReturn;
             uint256 lenderReturnFee = (lenderReturn - totalMatched) * LENDER_RETURN_FEE / BPS;
@@ -287,9 +282,36 @@ contract BloomPool is IBloomPool, ISwapRecipient, ERC20 {
     function emergencyWithdraw() external onlyState(State.EmergencyExit) {
         uint256 underlyingBalance = UNDERLYING_TOKEN.balanceOf(address(this));
         uint256 billBalance = BILL_TOKEN.balanceOf(address(this));
+        uint256 underlyingPrice = 1e8;
 
-        IOracle underlyingOracle = IOracle(ISwapFacility(SWAP_FACILITY).billyTokenOracle());
-        IOracle billOracle = IOracle(ISwapFacility(SWAP_FACILITY).underlyingTokenOracle());
+        IOracle billOracle = IOracle(ISwapFacility(SWAP_FACILITY).billyTokenOracle());
+        uint256 currentBillPrice = uint256(billOracle.latestAnswer());
+        if (currentBillPrice <= 0) revert OracleAnswerNegative();
+
+        uint256 underlyingDecimals = ERC20(UNDERLYING_TOKEN).decimals();
+        uint256 billDecimals = ERC20(BILL_TOKEN).decimals();
+        uint256 scalingFactor = 10 ** (billDecimals - underlyingDecimals);
+        
+        uint256 additionalValue = BILL_TOKEN.balanceOf(address(this)) * currentBillPrice / underlyingPrice / scalingFactor;
+        uint256 expectedTotalBalance = underlyingBalance + additionalValue;
+       
+        uint256 lenderDistro;
+        uint256 borrowerDistro;
+        uint256 totalMatched;
+        bool yieldGenerating;
+        // If we are in the emergency exit state before the end of the pool phase then we
+        //    know this exit occured during the pre-hold swap phase, so users should be able
+        //    to redeem USDC 1 for 1.
+        if (block.timestamp >= POOL_PHASE_END) {
+            totalMatched = totalMatchAmount();
+            lenderDistro = _calculateLenderReturn(totalMatched, expectedTotalBalance);
+            borrowerDistro = expectedTotalBalance - lenderDistro;
+            yieldGenerating = true;
+        } else {
+            lenderDistro = lenders.totalAssetsCommitted;
+            borrowerDistro = expectedTotalBalance - lenderDistro;
+            yieldGenerating = false;
+        }
 
         if (underlyingBalance > 0) {
             UNDERLYING_TOKEN.safeTransferAll(EMERGENCY_HANDLER);
@@ -301,12 +323,21 @@ contract BloomPool is IBloomPool, ISwapRecipient, ERC20 {
             emit EmergencyWithdrawExecuted(address(this), EMERGENCY_HANDLER, billBalance);
         }
 
-        IEmergencyHandler(EMERGENCY_HANDLER).registerPool(
-            UNDERLYING_TOKEN,
-            BILL_TOKEN,
-            underlyingOracle,
-            billOracle
+        IEmergencyHandler.RedemptionInfo memory redemptionInfo = IEmergencyHandler.RedemptionInfo(
+            IEmergencyHandler.Token(UNDERLYING_TOKEN, underlyingPrice, underlyingDecimals),
+            IEmergencyHandler.Token(BILL_TOKEN, currentBillPrice, billDecimals),
+            IEmergencyHandler.PoolAccounting(
+                lenderDistro,
+                borrowerDistro,
+                totalMatched,
+                totalMatched * BPS / LEVERAGE_BPS,
+                underlyingBalance,
+                billBalance
+            ),
+            yieldGenerating
         );
+
+        IEmergencyHandler(EMERGENCY_HANDLER).registerPool(redemptionInfo);
     }
 
     function executeEmergencyBurn(
@@ -374,5 +405,11 @@ contract BloomPool is IBloomPool, ISwapRecipient, ERC20 {
 
     function getDistributionInfo() external view returns (uint128, uint128, uint128, uint128) {
         return (borrowerDistribution, totalBorrowerShares, lenderDistribution, totalLenderShares);
+    }
+
+    function _calculateLenderReturn(uint256 totalMatched, uint256 outAmount) internal view returns (uint256) {
+        uint256 rateAppreciation = IBPSFeed(LENDER_RETURN_BPS_FEED).getWeightedRate() - BPS;
+        uint256 yieldEarned = totalMatched * rateAppreciation * POOL_PHASE_DURATION / ONE_YEAR / BPS;
+        return Math.min(totalMatched + yieldEarned, outAmount);
     }
 }

--- a/src/EmergencyHandler.sol
+++ b/src/EmergencyHandler.sol
@@ -56,7 +56,7 @@ contract EmergencyHandler is IEmergencyHandler, Ownable2Step {
         if (tokenAmount == 0) revert NoTokensToRedeem();
         pool.executeEmergencyBurn(msg.sender, tokenAmount);
 
-        uint256 amount = tokenAmount * info.rate / token.decimals();
+        uint256 amount = tokenAmount * info.rate / ERC20(redeemToken).decimals();
         redeemToken.safeTransfer(msg.sender, amount);
 
         return amount;
@@ -70,7 +70,7 @@ contract EmergencyHandler is IEmergencyHandler, Ownable2Step {
         uint256 id
     ) external override returns (uint256) {
         RedemptionInfo memory info = redemptionInfo[address(pool)];
-        address reedemToken = info.token;
+        address redeemToken = info.token;
 
         AssetCommitment memory commitment = pool.getBorrowCommitment(id);
         if (commitment.owner != msg.sender) revert InvalidOwner();
@@ -81,8 +81,8 @@ contract EmergencyHandler is IEmergencyHandler, Ownable2Step {
             borrowerClaimStatus[address(pool)][id] = true;
         }
 
-        uint256 amount = commitment.committedAmount * info.rate / ERC20(reedemToken).decimals();
-        reedemToken.safeTransfer(msg.sender, amount);
+        uint256 amount = commitment.committedAmount * info.rate / ERC20(redeemToken).decimals();
+        redeemToken.safeTransfer(msg.sender, amount);
         
         return amount;
     }

--- a/src/EmergencyHandler.sol
+++ b/src/EmergencyHandler.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: BUSL-1.1
+/*
+██████╗░██╗░░░░░░█████╗░░█████╗░███╗░░░███╗
+██╔══██╗██║░░░░░██╔══██╗██╔══██╗████╗░████║
+██████╦╝██║░░░░░██║░░██║██║░░██║██╔████╔██║
+██╔══██╗██║░░░░░██║░░██║██║░░██║██║╚██╔╝██║
+██████╦╝███████╗╚█████╔╝╚█████╔╝██║░╚═╝░██║
+╚═════╝░╚══════╝░╚════╝░░╚════╝░╚═╝░░░░░╚═╝
+*/
+
+pragma solidity ^0.8.19;
+
+import {Ownable2Step} from "openzeppelin-contracts/contracts/access/Ownable2Step.sol";
+import {ERC20} from "solmate/tokens/ERC20.sol";
+
+import {IEmergencyHandler, IOracle} from "./interfaces/IEmergencyHandler.sol";
+import {ExchangeRateRegistry} from "./helpers/ExchangeRateRegistry.sol";
+import {CommitmentsLib, Commitments, AssetCommitment} from "./lib/CommitmentsLib.sol";
+import {SafeTransferLib} from "solady/utils/SafeTransferLib.sol";
+import {BloomPool} from "./BloomPool.sol";
+
+/**
+ * @title EmergencyHandler
+ * @notice Allows users to redeem their funds from a Bloom Pool in emergency mode
+ * @dev This contract must correspond to a specific ExchangeRateRegistry
+ */
+contract EmergencyHandler is IEmergencyHandler, Ownable2Step {
+    using SafeTransferLib for address;
+    // =================== Storage ===================
+
+    ExchangeRateRegistry public immutable REGISTRY;
+    mapping(address => RedemptionInfo) public redemptionInfo;
+    
+    // ================== Modifiers ==================
+
+    modifier onlyPool() {
+        (bool registered, , ) = REGISTRY.tokenInfos(msg.sender);
+        if (!registered) revert CallerNotBloomPool();
+        _;
+    }
+
+    constructor(address _registry) Ownable2Step() {
+        REGISTRY = ExchangeRateRegistry(_registry);
+    }
+
+    /**
+     * @inheritdoc IEmergencyHandler
+     */
+    function redeem(BloomPool pool) external override returns (uint256) {
+        RedemptionInfo memory info = redemptionInfo[address(pool)];
+        address redeemToken = info.token;
+        if (redeemToken == address(0)) revert PoolNotRegistered();
+        
+        uint256 tokenAmount = pool.balanceOf(msg.sender);
+        if (tokenAmount == 0) revert NoTokensToRedeem();
+        // TODO implement emergency burn function here
+
+        uint256 amount = tokenAmount * info.rate / 1e18;
+        redeemToken.safeTransfer(msg.sender, amount);
+
+        return amount;
+    }
+
+    /**
+     * @inheritdoc IEmergencyHandler
+     */
+    // TODO add protections against people constantly redeeming
+    function redeem(
+        BloomPool pool,
+        uint256 id
+    ) external override returns (uint256) {
+        RedemptionInfo memory info = redemptionInfo[address(pool)];
+        AssetCommitment memory commitment = pool.getBorrowCommitment(id);
+        if (commitment.owner != msg.sender) revert InvalidOwner();
+
+        uint256 amount = commitment.committedAmount * info.rate / 1e18;
+        info.token.safeTransfer(msg.sender, amount);
+        return amount;
+    }
+
+    /**
+     * @inheritdoc IEmergencyHandler
+     */
+    // TODO: Add token scaling
+    function registerPool(IOracle _tokenOracle, address _asset) external override onlyPool {
+        (, int256 answer,, uint256 updatedAt,) = _tokenOracle.latestRoundData();
+        if (answer <= 0) revert OracleAnswerNegative();
+        // TODO: Need to scale
+        redemptionInfo[msg.sender] = RedemptionInfo(_asset, uint256(answer));
+    }
+}

--- a/src/EmergencyHandler.sol
+++ b/src/EmergencyHandler.sol
@@ -17,7 +17,7 @@ import {IEmergencyHandler, IOracle} from "./interfaces/IEmergencyHandler.sol";
 import {ExchangeRateRegistry} from "./helpers/ExchangeRateRegistry.sol";
 import {AssetCommitment} from "./lib/CommitmentsLib.sol";
 import {SafeTransferLib} from "solady/utils/SafeTransferLib.sol";
-import {BloomPool} from "./BloomPool.sol";
+import {IBloomPool} from "./interfaces/IBloomPool.sol";
 
 /**
  * @title EmergencyHandler
@@ -30,8 +30,8 @@ contract EmergencyHandler is IEmergencyHandler, Ownable2Step {
 
     ExchangeRateRegistry public immutable REGISTRY;
     mapping(address => RedemptionInfo) public redemptionInfo;
-    mapping(address => mapping(uint256 => bool)) private borrowerClaimStatus;
-    
+    mapping(address => mapping(uint256 => bool)) public borrowerClaimStatus;
+    event log(string message, uint256 value);
     // ================== Modifiers ==================
 
     modifier onlyPool() {
@@ -47,16 +47,18 @@ contract EmergencyHandler is IEmergencyHandler, Ownable2Step {
     /**
      * @inheritdoc IEmergencyHandler
      */
-    function redeem(BloomPool pool) external override returns (uint256) {
+    function redeem(IBloomPool pool) external override returns (uint256) {
         RedemptionInfo memory info = redemptionInfo[address(pool)];
         address redeemToken = info.token;
         if (redeemToken == address(0)) revert PoolNotRegistered();
         
-        uint256 tokenAmount = pool.balanceOf(msg.sender);
+        uint256 tokenAmount = ERC20(address(pool)).balanceOf(msg.sender);
         if (tokenAmount == 0) revert NoTokensToRedeem();
         pool.executeEmergencyBurn(msg.sender, tokenAmount);
 
-        uint256 amount = tokenAmount * info.rate / ERC20(redeemToken).decimals();
+        // BloomPool decimals are the same as the underlying token, so we scale down by the oracle's decimals
+        uint256 amount = tokenAmount * info.rate / 10**info.rateDecimals;
+        
         redeemToken.safeTransfer(msg.sender, amount);
 
         return amount;
@@ -66,22 +68,36 @@ contract EmergencyHandler is IEmergencyHandler, Ownable2Step {
      * @inheritdoc IEmergencyHandler
      */
     function redeem(
-        BloomPool pool,
+        IBloomPool pool,
         uint256 id
     ) external override returns (uint256) {
+        uint256 amount;
         RedemptionInfo memory info = redemptionInfo[address(pool)];
         address redeemToken = info.token;
 
         AssetCommitment memory commitment = pool.getBorrowCommitment(id);
         if (commitment.owner != msg.sender) revert InvalidOwner();
 
-        if (borrowerClaimStatus[address(pool)][id] == false) {
+        if (borrowerClaimStatus[address(pool)][id]) {
             revert BorrowerAlreadyClaimed();
         } else {
             borrowerClaimStatus[address(pool)][id] = true;
         }
 
-        uint256 amount = commitment.committedAmount * info.rate / ERC20(redeemToken).decimals();
+        uint256 redeemDecimals = ERC20(redeemToken).decimals();
+        uint256 underlyingDecimals = ERC20(address(pool)).decimals();
+
+        // Check if this logic is needed or is overkill
+        if (redeemDecimals == underlyingDecimals) {
+            amount = commitment.committedAmount * info.rate / 10**info.rateDecimals;
+        } else if (redeemDecimals > underlyingDecimals) {
+            uint256 scalingFactor = 10 ** (redeemDecimals - underlyingDecimals);
+            amount = commitment.committedAmount * info.rate * scalingFactor / 10**info.rateDecimals;
+        } else {
+            uint256 scalingFactor = 10 ** (underlyingDecimals - redeemDecimals);
+            amount = commitment.committedAmount * info.rate / 10**info.rateDecimals / scalingFactor;
+        }
+
         redeemToken.safeTransfer(msg.sender, amount);
         
         return amount;
@@ -95,6 +111,6 @@ contract EmergencyHandler is IEmergencyHandler, Ownable2Step {
     function registerPool(IOracle _tokenOracle, address _asset) external override onlyPool {
         (, int256 answer,, uint256 updatedAt,) = _tokenOracle.latestRoundData();
         if (answer <= 0) revert OracleAnswerNegative();
-        redemptionInfo[msg.sender] = RedemptionInfo(_asset, uint256(answer));
+        redemptionInfo[msg.sender] = RedemptionInfo(_asset, uint256(answer), _tokenOracle.decimals());
     }
 }

--- a/src/EmergencyHandler.sol
+++ b/src/EmergencyHandler.sol
@@ -15,7 +15,7 @@ import {ERC20} from "solmate/tokens/ERC20.sol";
 
 import {IEmergencyHandler, IOracle} from "./interfaces/IEmergencyHandler.sol";
 import {ExchangeRateRegistry} from "./helpers/ExchangeRateRegistry.sol";
-import {CommitmentsLib, Commitments, AssetCommitment} from "./lib/CommitmentsLib.sol";
+import {AssetCommitment} from "./lib/CommitmentsLib.sol";
 import {SafeTransferLib} from "solady/utils/SafeTransferLib.sol";
 import {BloomPool} from "./BloomPool.sol";
 
@@ -30,6 +30,7 @@ contract EmergencyHandler is IEmergencyHandler, Ownable2Step {
 
     ExchangeRateRegistry public immutable REGISTRY;
     mapping(address => RedemptionInfo) public redemptionInfo;
+    mapping(address => mapping(uint256 => bool)) private borrowerClaimStatus;
     
     // ================== Modifiers ==================
 
@@ -64,28 +65,31 @@ contract EmergencyHandler is IEmergencyHandler, Ownable2Step {
     /**
      * @inheritdoc IEmergencyHandler
      */
-    // TODO add protections against people constantly redeeming
     function redeem(
         BloomPool pool,
         uint256 id
     ) external override returns (uint256) {
         RedemptionInfo memory info = redemptionInfo[address(pool)];
+        address reedemToken = info.token;
+
         AssetCommitment memory commitment = pool.getBorrowCommitment(id);
         if (commitment.owner != msg.sender) revert InvalidOwner();
+        if (borrowerClaimStatus[address(pool)][id] == false) revert BorrowerAlreadyClaimed();
 
-        uint256 amount = commitment.committedAmount * info.rate / 1e18;
-        info.token.safeTransfer(msg.sender, amount);
+        borrowerClaimStatus[address(pool)][id] = true;
+        uint256 amount = commitment.committedAmount * info.rate / ERC20(reedemToken).decimals();
+        reedemToken.safeTransfer(msg.sender, amount);
+        
         return amount;
     }
 
     /**
      * @inheritdoc IEmergencyHandler
      */
-    // TODO: Add token scaling
+    // TODO: Maybe add more checks on rates and update times
     function registerPool(IOracle _tokenOracle, address _asset) external override onlyPool {
         (, int256 answer,, uint256 updatedAt,) = _tokenOracle.latestRoundData();
         if (answer <= 0) revert OracleAnswerNegative();
-        // TODO: Need to scale
         redemptionInfo[msg.sender] = RedemptionInfo(_asset, uint256(answer));
     }
 }

--- a/src/EmergencyHandler.sol
+++ b/src/EmergencyHandler.sol
@@ -54,9 +54,9 @@ contract EmergencyHandler is IEmergencyHandler, Ownable2Step {
         
         uint256 tokenAmount = pool.balanceOf(msg.sender);
         if (tokenAmount == 0) revert NoTokensToRedeem();
-        // TODO implement emergency burn function here
+        pool.executeEmergencyBurn(msg.sender, tokenAmount);
 
-        uint256 amount = tokenAmount * info.rate / 1e18;
+        uint256 amount = tokenAmount * info.rate / token.decimals();
         redeemToken.safeTransfer(msg.sender, amount);
 
         return amount;
@@ -74,9 +74,13 @@ contract EmergencyHandler is IEmergencyHandler, Ownable2Step {
 
         AssetCommitment memory commitment = pool.getBorrowCommitment(id);
         if (commitment.owner != msg.sender) revert InvalidOwner();
-        if (borrowerClaimStatus[address(pool)][id] == false) revert BorrowerAlreadyClaimed();
 
-        borrowerClaimStatus[address(pool)][id] = true;
+        if (borrowerClaimStatus[address(pool)][id] == false) {
+            revert BorrowerAlreadyClaimed();
+        } else {
+            borrowerClaimStatus[address(pool)][id] = true;
+        }
+
         uint256 amount = commitment.committedAmount * info.rate / ERC20(reedemToken).decimals();
         reedemToken.safeTransfer(msg.sender, amount);
         

--- a/src/EmergencyHandler.sol
+++ b/src/EmergencyHandler.sol
@@ -10,14 +10,15 @@
 
 pragma solidity ^0.8.19;
 
-import {Ownable2Step} from "openzeppelin-contracts/contracts/access/Ownable2Step.sol";
 import {ERC20} from "solmate/tokens/ERC20.sol";
+import {Ownable2Step} from "openzeppelin-contracts/contracts/access/Ownable2Step.sol";
 
-import {IEmergencyHandler, IOracle} from "./interfaces/IEmergencyHandler.sol";
-import {ExchangeRateRegistry} from "./helpers/ExchangeRateRegistry.sol";
 import {AssetCommitment} from "./lib/CommitmentsLib.sol";
+import {ExchangeRateRegistry} from "./helpers/ExchangeRateRegistry.sol";
 import {SafeTransferLib} from "solady/utils/SafeTransferLib.sol";
+
 import {IBloomPool} from "./interfaces/IBloomPool.sol";
+import {IEmergencyHandler, IOracle} from "./interfaces/IEmergencyHandler.sol";
 
 /**
  * @title EmergencyHandler
@@ -31,7 +32,7 @@ contract EmergencyHandler is IEmergencyHandler, Ownable2Step {
     ExchangeRateRegistry public immutable REGISTRY;
     mapping(address => RedemptionInfo) public redemptionInfo;
     mapping(address => mapping(uint256 => bool)) public borrowerClaimStatus;
-    event log(string message, uint256 value);
+
     // ================== Modifiers ==================
 
     modifier onlyPool() {
@@ -58,9 +59,7 @@ contract EmergencyHandler is IEmergencyHandler, Ownable2Step {
 
         // BloomPool decimals are the same as the underlying token, so we scale down by the oracle's decimals
         uint256 amount = tokenAmount * info.rate / 10**info.rateDecimals;
-        
         redeemToken.safeTransfer(msg.sender, amount);
-
         return amount;
     }
 
@@ -87,7 +86,6 @@ contract EmergencyHandler is IEmergencyHandler, Ownable2Step {
         uint256 redeemDecimals = ERC20(redeemToken).decimals();
         uint256 underlyingDecimals = ERC20(address(pool)).decimals();
 
-        // Check if this logic is needed or is overkill
         if (redeemDecimals == underlyingDecimals) {
             amount = commitment.committedAmount * info.rate / 10**info.rateDecimals;
         } else if (redeemDecimals > underlyingDecimals) {
@@ -99,7 +97,6 @@ contract EmergencyHandler is IEmergencyHandler, Ownable2Step {
         }
 
         redeemToken.safeTransfer(msg.sender, amount);
-        
         return amount;
     }
 

--- a/src/EmergencyHandler.sol
+++ b/src/EmergencyHandler.sol
@@ -40,8 +40,8 @@ contract EmergencyHandler is IEmergencyHandler, Ownable2Step {
         _;
     }
 
-    constructor(address _registry) Ownable2Step() {
-        REGISTRY = ExchangeRateRegistry(_registry);
+    constructor(ExchangeRateRegistry _registry) Ownable2Step() {
+        REGISTRY = _registry;
     }
 
     /**
@@ -91,6 +91,7 @@ contract EmergencyHandler is IEmergencyHandler, Ownable2Step {
      * @inheritdoc IEmergencyHandler
      */
     // TODO: Maybe add more checks on rates and update times
+    // TODO: Add support for multiple registrations of a single pool
     function registerPool(IOracle _tokenOracle, address _asset) external override onlyPool {
         (, int256 answer,, uint256 updatedAt,) = _tokenOracle.latestRoundData();
         if (answer <= 0) revert OracleAnswerNegative();

--- a/src/interfaces/IBloomPool.sol
+++ b/src/interfaces/IBloomPool.sol
@@ -55,7 +55,7 @@ interface IBloomPool {
     event BorrowerWithdraw(address indexed owner, uint256 indexed id, uint256 amount);
     event LenderWithdraw(address indexed owner, uint256 sharesRedeemed, uint256 amount);
 
-    event EmergencyWithdraw(address indexed to);
+    event EmergencyWithdrawExecuted(address indexed from, address indexed to, uint256 amount);
     event EmergencyBurn(address indexed user, uint256 amount);
 
     /// @notice Initiates the pre-hold swap.

--- a/src/interfaces/IBloomPool.sol
+++ b/src/interfaces/IBloomPool.sol
@@ -88,8 +88,11 @@ interface IBloomPool {
 
     /**
      * @notice Burns TBY shares when users redeem from the EmergencyHandler
+     * @dev This is a permissioned function that can only be called by the EmergencyHandler contract
+     * @param from The account from which the TBY tokens will be burned from
+     * @param amount The amount of tokens to burn
      */
-    function executeEmergencyBurn() external;
+    function executeEmergencyBurn(address from, uint256 amount) external;
 
     /**
      * @notice Processes a borrower's commit, calculates the included and excluded amounts, and refunds any unmatched amounts.

--- a/src/interfaces/IBloomPool.sol
+++ b/src/interfaces/IBloomPool.sol
@@ -56,6 +56,7 @@ interface IBloomPool {
     event LenderWithdraw(address indexed owner, uint256 sharesRedeemed, uint256 amount);
 
     event EmergencyWithdraw(address indexed to);
+    event EmergencyBurn(address indexed user, uint256 amount);
 
     /// @notice Initiates the pre-hold swap.
     function initiatePreHoldSwap(bytes32[] calldata proof) external;
@@ -77,6 +78,18 @@ interface IBloomPool {
      * @return newCommitmentId The commitment ID for the lender deposit.
      */
     function depositLender(uint256 amount) external returns (uint256 newCommitmentId);
+
+    /**
+     * @notice Sends all funds to the EmergencyHandler contract
+     * @dev This is a permissioned function that can only be executed by the owner of the BloomPool
+     *     It can only be executed when the pool is in Emergency mode.
+     */
+    function emergencyWithdraw() external;
+
+    /**
+     * @notice Burns TBY shares when users redeem from the EmergencyHandler
+     */
+    function executeEmergencyBurn() external;
 
     /**
      * @notice Processes a borrower's commit, calculates the included and excluded amounts, and refunds any unmatched amounts.

--- a/src/interfaces/IBloomPool.sol
+++ b/src/interfaces/IBloomPool.sol
@@ -35,7 +35,7 @@ interface IBloomPool {
     error NotWhitelisted();
     error NoCommitToProcess();
     error CommitTooSmall();
-
+    error OracleAnswerNegative();
     error CanOnlyWithdrawProcessedCommit(uint256 id);
     error NoCommitToWithdraw();
 

--- a/src/interfaces/IEmergencyHandler.sol
+++ b/src/interfaces/IEmergencyHandler.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: BUSL-1.1
+/*
+██████╗░██╗░░░░░░█████╗░░█████╗░███╗░░░███╗
+██╔══██╗██║░░░░░██╔══██╗██╔══██╗████╗░████║
+██████╦╝██║░░░░░██║░░██║██║░░██║██╔████╔██║
+██╔══██╗██║░░░░░██║░░██║██║░░██║██║╚██╔╝██║
+██████╦╝███████╗╚█████╔╝╚█████╔╝██║░╚═╝░██║
+╚═════╝░╚══════╝░╚════╝░░╚════╝░╚═╝░░░░░╚═╝
+*/
+
+pragma solidity ^0.8.0;
+
+import {BloomPool} from "../BloomPool.sol";
+import {IOracle} from "./IOracle.sol";
+
+interface IEmergencyHandler {
+
+    error CallerNotBloomPool();
+    error NoTokensToRedeem();
+    error OracleAnswerNegative();
+    error PoolNotRegistered();
+    error InvalidOwner();
+
+    struct RedemptionInfo {
+        address token;
+        uint256 rate; 
+    }
+
+    /**
+     * @notice Redeem underlying assets from a Bloom Pool that are in emergency mode
+     * @param _pool BloomPool that the funds in the emergency handler contract orginated from
+     * @return amount of underlying assets redeemed
+     */
+    function redeem(BloomPool _pool) external returns (uint256);
+
+    /**
+     * @notice Redeem Bill Tokens 
+     * @param _pool BloomPool that the funds in the emergency handler contract orginated from
+     * @param _id Id of the borrowers commit in the corresponding BloomPool
+     * @return amount of Bill Tokens redeemed
+     */
+    function redeem(BloomPool _pool, uint256 _id) external returns (uint256);
+    
+    /**
+     * @notice Registers a Bloom Pool in the Emergency Handler
+     * @param _asset Address of the asset being set to the EmergencyHandler
+     */
+    function registerPool(IOracle _tokenOracle, address _asset) external;
+}

--- a/src/interfaces/IEmergencyHandler.sol
+++ b/src/interfaces/IEmergencyHandler.sol
@@ -20,12 +20,18 @@ interface IEmergencyHandler {
     error NoTokensToRedeem();
     error OracleAnswerNegative();
     error PoolNotRegistered();
+    error PoolAlreadyRegistered();
     error InvalidOwner();
 
-    struct RedemptionInfo {
+    struct Token {
         address token;
         uint256 rate;
         uint256 rateDecimals;
+    }
+
+    struct RedemptionInfo {
+        Token underlyingToken;
+        Token billToken;
     }
 
     /**
@@ -45,7 +51,15 @@ interface IEmergencyHandler {
     
     /**
      * @notice Registers a Bloom Pool in the Emergency Handler
-     * @param _asset Address of the asset being set to the EmergencyHandler
+     * @param underlyingToken Underlying token of the Bloom Pool
+     * @param billToken Bill token of the Bloom Pool
+     * @param underlyingOracle Oracle for the underlying token
+     * @param billOracle Oracle for the bill token
      */
-    function registerPool(IOracle _tokenOracle, address _asset) external;
+    function registerPool(
+        address underlyingToken,
+        address billToken,
+        IOracle underlyingOracle,
+        IOracle billOracle
+    ) external;
 }

--- a/src/interfaces/IEmergencyHandler.sol
+++ b/src/interfaces/IEmergencyHandler.sol
@@ -15,6 +15,7 @@ import {IOracle} from "./IOracle.sol";
 
 interface IEmergencyHandler {
 
+    error BorrowerAlreadyClaimed();
     error CallerNotBloomPool();
     error NoTokensToRedeem();
     error OracleAnswerNegative();
@@ -23,7 +24,7 @@ interface IEmergencyHandler {
 
     struct RedemptionInfo {
         address token;
-        uint256 rate; 
+        uint256 rate;
     }
 
     /**

--- a/src/interfaces/IEmergencyHandler.sol
+++ b/src/interfaces/IEmergencyHandler.sol
@@ -18,7 +18,7 @@ interface IEmergencyHandler {
     error BorrowerAlreadyClaimed();
     error CallerNotBloomPool();
     error NoTokensToRedeem();
-    error OracleAnswerNegative();
+    error NotWhitelisted();
     error PoolNotRegistered();
     error PoolAlreadyRegistered();
     error InvalidOwner();
@@ -29,37 +29,54 @@ interface IEmergencyHandler {
         uint256 rateDecimals;
     }
 
+    struct PoolAccounting {
+        uint256 lenderDistro; // Underlying assets available for lenders
+        uint256 borrowerDistro; // Underlying assets available for borrowers
+        uint256 lenderShares; // Total shares available for lenders
+        uint256 borrowerShares; // Total shares available for borrowers
+        uint256 totalUnderlying; // Total underlying assets from the pool
+        uint256 totalBill; // Total bill assets from the pool
+    }
+
     struct RedemptionInfo {
         Token underlyingToken;
         Token billToken;
+        PoolAccounting accounting;
+        bool yieldGenerated;
+    }
+
+    struct ClaimStatus {
+        bool claimed;
+        uint256 amountRemaining;
     }
 
     /**
-     * @notice Redeem underlying assets from a Bloom Pool that are in emergency mode
+     * @notice Redeem underlying assets for lenders of a BloomPool in Emergency Exit mode
      * @param _pool BloomPool that the funds in the emergency handler contract orginated from
      * @return amount of underlying assets redeemed
      */
     function redeem(IBloomPool _pool) external returns (uint256);
 
     /**
-     * @notice Redeem Bill Tokens 
-     * @param _pool BloomPool that the funds in the emergency handler contract orginated from
-     * @param _id Id of the borrowers commit in the corresponding BloomPool
-     * @return amount of Bill Tokens redeemed
+     * @notice  Redeem underlying assets for borrowers of a BloomPool in Emergency Exit mode
+     * @param pool BloomPool that the funds in the emergency handler contract orginated from
+     * @param id Id of the borrowers commit in the corresponding BloomPool
+     * @return amount of underlying assets redeemed
      */
-    function redeem(IBloomPool _pool, uint256 _id) external returns (uint256);
+    function redeem(IBloomPool pool, uint256 id) external returns (uint256);
+
+    /**
+     * @notice Allows Market Makers to swap underlying assets for bill tokens
+     * @param pool BloomPool that the funds in the emergency handler contract orginated from
+     * @param underlyingIn Amount of underlying assets to swap
+     * @param proof Whitelist proof data, prevents non-approved maket makers from swapping
+     * @return amount of bill tokens received
+     */
+    function swap(IBloomPool pool, uint256 underlyingIn, bytes32[] calldata proof) external returns (uint256);
     
     /**
      * @notice Registers a Bloom Pool in the Emergency Handler
-     * @param underlyingToken Underlying token of the Bloom Pool
-     * @param billToken Bill token of the Bloom Pool
-     * @param underlyingOracle Oracle for the underlying token
-     * @param billOracle Oracle for the bill token
-     */
-    function registerPool(
-        address underlyingToken,
-        address billToken,
-        IOracle underlyingOracle,
-        IOracle billOracle
-    ) external;
+     * @param redemptionInfo RedemptionInfo struct containing the pool's accounting and oracle information
+    */
+    function registerPool(RedemptionInfo memory redemptionInfo) external;
 }

--- a/src/interfaces/IEmergencyHandler.sol
+++ b/src/interfaces/IEmergencyHandler.sol
@@ -10,7 +10,7 @@
 
 pragma solidity ^0.8.0;
 
-import {BloomPool} from "../BloomPool.sol";
+import {IBloomPool} from "./IBloomPool.sol";
 import {IOracle} from "./IOracle.sol";
 
 interface IEmergencyHandler {
@@ -25,6 +25,7 @@ interface IEmergencyHandler {
     struct RedemptionInfo {
         address token;
         uint256 rate;
+        uint256 rateDecimals;
     }
 
     /**
@@ -32,7 +33,7 @@ interface IEmergencyHandler {
      * @param _pool BloomPool that the funds in the emergency handler contract orginated from
      * @return amount of underlying assets redeemed
      */
-    function redeem(BloomPool _pool) external returns (uint256);
+    function redeem(IBloomPool _pool) external returns (uint256);
 
     /**
      * @notice Redeem Bill Tokens 
@@ -40,7 +41,7 @@ interface IEmergencyHandler {
      * @param _id Id of the borrowers commit in the corresponding BloomPool
      * @return amount of Bill Tokens redeemed
      */
-    function redeem(BloomPool _pool, uint256 _id) external returns (uint256);
+    function redeem(IBloomPool _pool, uint256 _id) external returns (uint256);
     
     /**
      * @notice Registers a Bloom Pool in the Emergency Handler

--- a/test/BloomFactory.t.sol
+++ b/test/BloomFactory.t.sol
@@ -77,7 +77,7 @@ contract BloomFactoryTest is Test {
     function testCreatePool() public {
         BloomPool pool = _newPoolInstance();
 
-        assertNotEq(address(pool), address(0));
+        assertFalse(address(pool) == address(0));
         assertEq(factory.getLastCreatedPool(), address(pool));
         assertEq(factory.isPoolFromFactory(address(pool)), true);
     }

--- a/test/BloomPool.t.sol
+++ b/test/BloomPool.t.sol
@@ -26,7 +26,7 @@ import {MockWhitelist} from "./mock/MockWhitelist.sol";
 import {MockSwapFacility} from "./mock/MockSwapFacility.sol";
 import {MockBPSFeed} from "./mock/MockBPSFeed.sol";
 import {MockOracle} from "./mock/MockOracle.sol";
-import {console2} from "forge-std/console2.sol";
+
 contract BloomPoolTest is Test {
     BloomPool internal pool;
 

--- a/test/BloomPool.t.sol
+++ b/test/BloomPool.t.sol
@@ -18,11 +18,15 @@ import {BloomPool, State, AssetCommitment} from "src/BloomPool.sol";
 import {IBloomPool} from "src/interfaces/IBloomPool.sol";
 import {IWhitelist} from "src/interfaces/IWhitelist.sol";
 import {IBPSFeed} from "src/interfaces/IBPSFeed.sol";
+import {ExchangeRateRegistry} from "src/helpers/ExchangeRateRegistry.sol";
+import {EmergencyHandler} from "src/EmergencyHandler.sol";
+
 import {MockERC20} from "./mock/MockERC20.sol";
 import {MockWhitelist} from "./mock/MockWhitelist.sol";
 import {MockSwapFacility} from "./mock/MockSwapFacility.sol";
 import {MockBPSFeed} from "./mock/MockBPSFeed.sol";
-
+import {MockOracle} from "./mock/MockOracle.sol";
+import {console2} from "forge-std/console2.sol";
 contract BloomPoolTest is Test {
     BloomPool internal pool;
 
@@ -30,9 +34,16 @@ contract BloomPoolTest is Test {
     MockERC20 internal billyToken;
     MockWhitelist internal whitelist;
     MockSwapFacility internal swap;
-    address internal treasury = makeAddr("treasury");
-    address internal emergencyHandler = makeAddr("emergencyHandler");
+    MockOracle internal stableOracle;
+    MockOracle internal billOracle;
     MockBPSFeed internal feed;
+
+    address internal treasury = makeAddr("treasury");
+    address internal multisig = makeAddr("multisig");
+    address internal factory = makeAddr("factory");
+    
+    ExchangeRateRegistry internal registry = new ExchangeRateRegistry(multisig, factory);
+    EmergencyHandler internal emergencyHandler = new EmergencyHandler(registry);
 
     uint256 internal commitPhaseDuration;
     uint256 internal poolPhaseDuration;
@@ -53,7 +64,7 @@ contract BloomPoolTest is Test {
     event BorrowerWithdraw(address indexed owner, uint256 indexed id, uint256 amount);
     event LenderWithdraw(address indexed owner, uint256 sharesRedeemed, uint256 amount);
     event Transfer(address indexed from, address indexed to, uint256 amount);
-    event EmergencyWithdraw(address indexed owner);
+    event EmergencyWithdrawExecuted(address indexed from, address indexed to, uint256 amount);
 
     function setUp() public {
         stableToken = new MockERC20(6);
@@ -61,7 +72,9 @@ contract BloomPoolTest is Test {
         billyToken = new MockERC20(18);
         vm.label(address(billyToken), "BillyToken");
         whitelist = new MockWhitelist();
-        swap = new MockSwapFacility(stableToken, billyToken);
+        stableOracle = new MockOracle(8);
+        billOracle = new MockOracle(8);
+        swap = new MockSwapFacility(stableToken, billyToken, stableOracle, billOracle);
         feed = new MockBPSFeed();
 
         feed.setRate(BPS_FEED_VALUE);
@@ -73,7 +86,7 @@ contract BloomPoolTest is Test {
             swapFacility: address(swap),
             treasury: treasury,
             leverageBps: 4 * BPS,
-            emergencyHandler: emergencyHandler,
+            emergencyHandler: address(emergencyHandler),
             minBorrowDeposit: 100.0e6,
             commitPhaseDuration: commitPhaseDuration = 3 days,
             swapTimeout: 7 days,
@@ -84,6 +97,11 @@ contract BloomPoolTest is Test {
             name: "Term Bound Token 6 month 2023-06-1",
             symbol: "TBT-1"
         });
+
+        // Register the pool in the exchange rate registry.
+        vm.startPrank(multisig);
+        registry.registerToken(pool);
+        vm.stopPrank();
     }
 
     function testDefaultState() public {
@@ -476,31 +494,30 @@ contract BloomPoolTest is Test {
         pool.initiatePreHoldSwap(new bytes32[](0));
 
         // Fails to emergency withdraw before the pre-hold swap timeout
-        vm.startPrank(emergencyHandler);
+        vm.startPrank(multisig);
         vm.expectRevert(abi.encodeWithSelector(IBloomPool.InvalidState.selector, (State.PendingPreHoldSwap)));
         pool.emergencyWithdraw();
         vm.stopPrank();
+
+        //Set up oracle pricing and token registration
+        stableOracle.setAnswer(1e8);
+        billOracle.setAnswer(1e8);
 
         // Fast Forward to Emergency Exit Period
         vm.warp(pool.POOL_PHASE_END());
         assertEq(pool.state(), State.EmergencyExit);
 
-        // Fails to revert with none emergency handler account
-        vm.startPrank(user);
-        vm.expectRevert(IBloomPool.NotEmergencyHandler.selector);
-        pool.emergencyWithdraw();
-        vm.stopPrank();
-
+        uint256 stableBalance = stableToken.balanceOf(address(pool));
         uint256 billyBalance = billyToken.balanceOf(address(pool));
 
-        vm.startPrank(emergencyHandler);
+        vm.startPrank(multisig);
         vm.expectEmit(true, true, true, true);
-        emit EmergencyWithdraw(emergencyHandler);
+        emit EmergencyWithdrawExecuted(address(pool), address(emergencyHandler), stableBalance);
         pool.emergencyWithdraw();
         vm.stopPrank();
         
-        assertEq(billyToken.balanceOf(emergencyHandler), billyBalance);
-        assertEq(billyToken.balanceOf(address(pool)), 0);
+        assertEq(stableToken.balanceOf(address(emergencyHandler)), stableBalance);
+        assertEq(stableToken.balanceOf(address(pool)), 0);
     }
 
     function testEmergencyWithdrawPostHold() public {
@@ -536,31 +553,27 @@ contract BloomPoolTest is Test {
         vm.warp(pool.POOL_PHASE_END());
 
         // Fails to emergency withdraw before the post-hold swap timeout
-        vm.startPrank(emergencyHandler);
+        vm.startPrank(multisig);
         vm.expectRevert(abi.encodeWithSelector(IBloomPool.InvalidState.selector, (State.PendingPostHoldSwap)));
         pool.emergencyWithdraw();
         vm.stopPrank();
+
+        stableOracle.setAnswer(1e8);
 
         // Fast Forward to Emergency Exit Period
         vm.warp(pool.POST_HOLD_SWAP_TIMEOUT_END());
         assertEq(pool.state(), State.EmergencyExit);
 
-        // Fails to revert with none emergency handler account
-        vm.startPrank(user);
-        vm.expectRevert(IBloomPool.NotEmergencyHandler.selector);
-        pool.emergencyWithdraw();
-        vm.stopPrank();
-
-        uint256 billyBalance = billyToken.balanceOf(address(pool));
+        uint256 stableBalance = stableToken.balanceOf(address(pool));
                 
-        vm.startPrank(emergencyHandler);
+        vm.startPrank(multisig);
         vm.expectEmit(true, true, true, true);
-        emit EmergencyWithdraw(emergencyHandler);
+        emit EmergencyWithdrawExecuted(address(pool), address(emergencyHandler), stableBalance);
         pool.emergencyWithdraw();
         vm.stopPrank();
         
-        assertEq(billyToken.balanceOf(emergencyHandler), billyBalance);
-        assertEq(billyToken.balanceOf(address(pool)), 0);
+        assertEq(stableToken.balanceOf(address(emergencyHandler)), stableBalance);
+        assertEq(stableToken.balanceOf(address(pool)), 0);
     }
 
     function assertEq(State a, State b) internal {

--- a/test/BloomPool.t.sol
+++ b/test/BloomPool.t.sol
@@ -559,6 +559,7 @@ contract BloomPoolTest is Test {
         vm.stopPrank();
 
         stableOracle.setAnswer(1e8);
+        billOracle.setAnswer(1e8);
 
         // Fast Forward to Emergency Exit Period
         vm.warp(pool.POST_HOLD_SWAP_TIMEOUT_END());

--- a/test/BloomPool.t.sol
+++ b/test/BloomPool.t.sol
@@ -478,7 +478,7 @@ contract BloomPoolTest is Test {
         // Fails to emergency withdraw before the pre-hold swap timeout
         vm.startPrank(emergencyHandler);
         vm.expectRevert(abi.encodeWithSelector(IBloomPool.InvalidState.selector, (State.PendingPreHoldSwap)));
-        pool.emergencyWithdrawTo(emergencyHandler);
+        pool.emergencyWithdraw();
         vm.stopPrank();
 
         // Fast Forward to Emergency Exit Period
@@ -488,7 +488,7 @@ contract BloomPoolTest is Test {
         // Fails to revert with none emergency handler account
         vm.startPrank(user);
         vm.expectRevert(IBloomPool.NotEmergencyHandler.selector);
-        pool.emergencyWithdrawTo(user);
+        pool.emergencyWithdraw();
         vm.stopPrank();
 
         uint256 billyBalance = billyToken.balanceOf(address(pool));
@@ -496,7 +496,7 @@ contract BloomPoolTest is Test {
         vm.startPrank(emergencyHandler);
         vm.expectEmit(true, true, true, true);
         emit EmergencyWithdraw(emergencyHandler);
-        pool.emergencyWithdrawTo(emergencyHandler);
+        pool.emergencyWithdraw();
         vm.stopPrank();
         
         assertEq(billyToken.balanceOf(emergencyHandler), billyBalance);
@@ -538,7 +538,7 @@ contract BloomPoolTest is Test {
         // Fails to emergency withdraw before the post-hold swap timeout
         vm.startPrank(emergencyHandler);
         vm.expectRevert(abi.encodeWithSelector(IBloomPool.InvalidState.selector, (State.PendingPostHoldSwap)));
-        pool.emergencyWithdrawTo(emergencyHandler);
+        pool.emergencyWithdraw();
         vm.stopPrank();
 
         // Fast Forward to Emergency Exit Period
@@ -548,7 +548,7 @@ contract BloomPoolTest is Test {
         // Fails to revert with none emergency handler account
         vm.startPrank(user);
         vm.expectRevert(IBloomPool.NotEmergencyHandler.selector);
-        pool.emergencyWithdrawTo(user);
+        pool.emergencyWithdraw();
         vm.stopPrank();
 
         uint256 billyBalance = billyToken.balanceOf(address(pool));
@@ -556,7 +556,7 @@ contract BloomPoolTest is Test {
         vm.startPrank(emergencyHandler);
         vm.expectEmit(true, true, true, true);
         emit EmergencyWithdraw(emergencyHandler);
-        pool.emergencyWithdrawTo(emergencyHandler);
+        pool.emergencyWithdraw();
         vm.stopPrank();
         
         assertEq(billyToken.balanceOf(emergencyHandler), billyBalance);

--- a/test/EmergencyHandler.t.sol
+++ b/test/EmergencyHandler.t.sol
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: BUSL-1.1
+/*
+██████╗░██╗░░░░░░█████╗░░█████╗░███╗░░░███╗
+██╔══██╗██║░░░░░██╔══██╗██╔══██╗████╗░████║
+██████╦╝██║░░░░░██║░░██║██║░░██║██╔████╔██║
+██╔══██╗██║░░░░░██║░░██║██║░░██║██║╚██╔╝██║
+██████╦╝███████╗╚█████╔╝╚█████╔╝██║░╚═╝░██║
+╚═════╝░╚══════╝░╚════╝░░╚════╝░╚═╝░░░░░╚═╝
+*/
+
+pragma solidity 0.8.19;
+
+import {Test} from "forge-std/Test.sol";
+
+import {MockERC20, ERC20} from "./mock/MockERC20.sol";
+import {MockBloomPool} from "./mock/MockBloomPool.sol";
+import {MockSwapFacility} from "./mock/MockSwapFacility.sol";
+import {MockOracle} from "./mock/MockOracle.sol";
+
+import {EmergencyHandler, IEmergencyHandler} from "src/EmergencyHandler.sol";
+import {ExchangeRateRegistry} from "src/helpers/ExchangeRateRegistry.sol";
+import {AssetCommitment} from "src/lib/CommitmentsLib.sol";
+
+import {IBloomPool} from "src/interfaces/IBloomPool.sol";
+
+contract EmergencyHandlerTest is Test {
+    address internal multisig = makeAddr("multisig");
+    MockERC20 internal stableToken;
+    MockERC20 internal billyToken;
+    MockBloomPool internal pool;
+    MockSwapFacility internal swap;
+    MockOracle internal stableOracle;
+    MockOracle internal billyOracle;
+    
+    ExchangeRateRegistry internal registry;
+    EmergencyHandler internal handler;
+
+    function setUp() public {
+        stableToken = new MockERC20(6);
+        billyToken = new MockERC20(18);
+        stableOracle = new MockOracle(8);
+        billyOracle = new MockOracle(8);
+        swap = new MockSwapFacility(stableToken, billyToken, stableOracle, billyOracle);
+        pool = new MockBloomPool(address(stableToken), address(billyToken), address(swap));
+        pool.setCommitPhaseEnd(block.timestamp + 100000);
+        address factory = makeAddr("factory");
+        registry = new ExchangeRateRegistry(multisig, factory);
+
+        vm.startPrank(multisig);
+        registry.registerToken(IBloomPool(address(pool)));
+        handler = new EmergencyHandler(registry);
+        vm.stopPrank();
+    }
+
+    function test_getRegistry() public {
+        assertEq(address(registry), address(handler.REGISTRY()));
+    }
+
+    function test_redemptionInfo() public {
+        _registerPool(stableToken, 100e6);
+
+        (address token, uint256 rate, ) = handler.redemptionInfo(address(pool));
+        assertEq(token, address(stableToken));
+        assertEq(rate, 1e8);
+    }
+
+    function test_borrowerClaimStatus() public {
+        _registerPool(billyToken, 100e6);
+
+        assertEq(handler.borrowerClaimStatus(address(pool),0), false);
+    }
+
+    function test_redeemLender() public {
+        address lender = makeAddr("lender");
+        MockERC20(address(pool)).mint(lender, 100e6);
+
+        _registerPool(stableToken, 100e6);
+
+        vm.startPrank(lender);
+        handler.redeem(IBloomPool(address(pool)));
+
+        assertEq(stableToken.balanceOf(lender), 100e6);
+        assertEq(ERC20(address(pool)).balanceOf(lender), 0);
+    }
+
+    function test_redeemBorrower() public {
+        address borrower = makeAddr("borrower");
+        _registerPool(billyToken, 100e18);
+
+        uint256 id = 0;
+
+        MockBloomPool.AssetCommitment memory commitment = MockBloomPool.AssetCommitment({
+            owner: borrower,
+            committedAmount: 100e6,
+            cumulativeAmountEnd: 100e6
+        });
+
+        pool.setBorrowerCommitment(id, commitment);
+        
+        vm.startPrank(borrower);
+        handler.redeem(IBloomPool(address(pool)), id);
+        vm.stopPrank();
+
+        assertEq(billyToken.balanceOf(borrower), 100e18);
+        assertEq(billyToken.balanceOf(address(handler)), 0);
+    }
+
+    function _registerPool(MockERC20 token, uint256 amount) internal {
+        pool.setState(MockBloomPool.State.EmergencyExit);
+        pool.setEmergencyHandler(address(handler));
+
+        if (token == stableToken) {
+            stableOracle.setAnswer(1e8);
+            stableToken.mint(address(handler), amount);
+
+            vm.startPrank(address(pool));
+            handler.registerPool(stableOracle, address(stableToken));
+            vm.stopPrank();
+        } else {
+            billyOracle.setAnswer(1e8);
+            billyToken.mint(address(handler), amount);
+
+            vm.startPrank(address(pool));
+            handler.registerPool(billyOracle, address(billyToken));
+            vm.stopPrank();
+        }        
+    }
+    
+}

--- a/test/EmergencyHandler.t.sol
+++ b/test/EmergencyHandler.t.sol
@@ -17,9 +17,9 @@ import {MockBloomPool} from "./mock/MockBloomPool.sol";
 import {MockSwapFacility} from "./mock/MockSwapFacility.sol";
 import {MockOracle} from "./mock/MockOracle.sol";
 
+import {AssetCommitment} from "src/lib/CommitmentsLib.sol";
 import {EmergencyHandler, IEmergencyHandler} from "src/EmergencyHandler.sol";
 import {ExchangeRateRegistry} from "src/helpers/ExchangeRateRegistry.sol";
-import {AssetCommitment} from "src/lib/CommitmentsLib.sol";
 
 import {IBloomPool} from "src/interfaces/IBloomPool.sol";
 

--- a/test/ExchangeRateRegistry.t.sol
+++ b/test/ExchangeRateRegistry.t.sol
@@ -21,6 +21,7 @@ import {MockERC20} from "./mock/MockERC20.sol";
 import {MockWhitelist} from "./mock/MockWhitelist.sol";
 import {MockSwapFacility} from "./mock/MockSwapFacility.sol";
 import {MockBPSFeed} from "./mock/MockBPSFeed.sol";
+import {MockOracle} from "./mock/MockOracle.sol";
 
 contract ExchangeRateRegistryTest is Test {
     BloomPool internal pool;
@@ -28,6 +29,8 @@ contract ExchangeRateRegistryTest is Test {
     MockERC20 internal billyToken;
     MockWhitelist internal whitelist;
     MockSwapFacility internal swap;
+    MockOracle internal oracle1;
+    MockOracle internal oracle2;
 
     address internal treasury = makeAddr("treasury");
     address internal registryOwner = makeAddr("owner");
@@ -57,7 +60,7 @@ contract ExchangeRateRegistryTest is Test {
         stableToken = new MockERC20(6);
         billyToken = new MockERC20(18);
         whitelist = new MockWhitelist();
-        swap = new MockSwapFacility(stableToken, billyToken);
+        swap = new MockSwapFacility(stableToken, billyToken, oracle1, oracle2);
         feed = new MockBPSFeed();
 
         feed.setRate(ORACLE_RATE);

--- a/test/ExchangeRateRegistry.t.sol
+++ b/test/ExchangeRateRegistry.t.sol
@@ -14,14 +14,16 @@ import {Test} from "forge-std/Test.sol";
 
 import {BloomPool, State, AssetCommitment} from "src/BloomPool.sol";
 import {ExchangeRateRegistry} from "src/helpers/ExchangeRateRegistry.sol";
-import {IBloomPool} from "src/interfaces/IBloomPool.sol";
-import {IWhitelist} from "src/interfaces/IWhitelist.sol";
-import {IBPSFeed} from "src/interfaces/IBPSFeed.sol";
+
 import {MockERC20} from "./mock/MockERC20.sol";
 import {MockWhitelist} from "./mock/MockWhitelist.sol";
 import {MockSwapFacility} from "./mock/MockSwapFacility.sol";
 import {MockBPSFeed} from "./mock/MockBPSFeed.sol";
 import {MockOracle} from "./mock/MockOracle.sol";
+
+import {IBloomPool} from "src/interfaces/IBloomPool.sol";
+import {IWhitelist} from "src/interfaces/IWhitelist.sol";
+import {IBPSFeed} from "src/interfaces/IBPSFeed.sol";
 
 contract ExchangeRateRegistryTest is Test {
     BloomPool internal pool;

--- a/test/mock/MockBloomPool.sol
+++ b/test/mock/MockBloomPool.sol
@@ -14,18 +14,52 @@ import {SafeTransferLib} from "solady/utils/SafeTransferLib.sol";
 import {ISwapFacility} from "src/interfaces/ISwapFacility.sol";
 import {MockERC20} from "./MockERC20.sol";
 
-contract MockBloomPool {
+error InvalidState(MockBloomPool.State current);
+error NotEmergencyHandler();
+
+contract MockBloomPool is MockERC20 {
     using SafeTransferLib for address;
 
     address public immutable underlyingToken;
     address public immutable billToken;
+    address public emergencyHandler;
+
+    uint256 public COMMIT_PHASE_END;
+    
+    mapping(uint256 => AssetCommitment) commitments;
+
+    State public state;
 
     ISwapFacility public immutable swap;
+    
+    enum State {
+        Normal,
+        EmergencyExit
+    }
 
-    constructor(address _underlyingToken, address _billToken, address _swap) {
+    struct AssetCommitment {
+        address owner;
+        uint128 committedAmount;
+        uint128 cumulativeAmountEnd;
+    }
+
+    modifier onlyState(State expectedState) {
+        if (state != expectedState) revert InvalidState(state);
+        _;
+    }
+
+    modifier onlyEmergencyHandler() {
+        if (msg.sender != emergencyHandler) revert NotEmergencyHandler();
+        _;
+    }
+
+    constructor(address _underlyingToken, address _billToken, address _swap) 
+        MockERC20(MockERC20(_underlyingToken).decimals())
+    {
         underlyingToken = _underlyingToken;
         billToken = _billToken;
         swap = ISwapFacility(_swap);
+        state = State.Normal;
     }
 
     function initiatePreHoldSwap() external {
@@ -41,4 +75,31 @@ contract MockBloomPool {
     }
 
     function completeSwap(address outToken, uint256 outAmount) external {}
+
+    function executeEmergencyBurn(
+        address account,
+        uint256 amount
+    ) external onlyState(State.EmergencyExit) onlyEmergencyHandler {
+        _burn(account, amount);
+    }
+
+    function getBorrowCommitment(uint256 id) external view returns (AssetCommitment memory) {
+        return commitments[id];
+    }
+
+    function setState(State newState) external {
+        state = newState;
+    }
+
+    function setEmergencyHandler(address newHandler) external {
+        emergencyHandler = newHandler;
+    }
+
+    function setBorrowerCommitment(uint256 id, AssetCommitment memory commitment) external {
+        commitments[id] = commitment;
+    }
+
+    function setCommitPhaseEnd(uint256 newCommitPhaseEnd) external {
+        COMMIT_PHASE_END = newCommitPhaseEnd;
+    }
 }

--- a/test/mock/MockBloomPool.sol
+++ b/test/mock/MockBloomPool.sol
@@ -102,4 +102,8 @@ contract MockBloomPool is MockERC20 {
     function setCommitPhaseEnd(uint256 newCommitPhaseEnd) external {
         COMMIT_PHASE_END = newCommitPhaseEnd;
     }
+
+    function SWAP_FACILITY() external view returns (address) {
+        return address(swap);
+    }
 }

--- a/test/mock/MockSwapFacility.sol
+++ b/test/mock/MockSwapFacility.sol
@@ -14,7 +14,9 @@ import {IMockSwapFacility} from "./interfaces/IMockSwapFacility.sol";
 
 import {MockERC20} from "./MockERC20.sol";
 import {MockOracle} from "./MockOracle.sol";
+
 import {ISwapRecipient} from "src/interfaces/ISwapRecipient.sol";
+import {IWhitelist} from "src/interfaces/IWhitelist.sol";
 
 contract MockSwapFacility is IMockSwapFacility {
     uint256 internal constant WAD = 1e18;
@@ -27,6 +29,7 @@ contract MockSwapFacility is IMockSwapFacility {
     address public immutable billyTokenOracle;
 
     uint256 public exchangeRate;
+    IWhitelist public whitelist;
 
     struct PendingSwap {
         address to;
@@ -76,5 +79,9 @@ contract MockSwapFacility is IMockSwapFacility {
         uint256 outAmount = inToken == address(token0) ? inAmount * WAD / exchangeRate : inAmount * exchangeRate / WAD;
 
         pendingSwaps.push(PendingSwap({to: msg.sender, token: MockERC20(outToken), amount: outAmount}));
+    }
+
+    function setWhitelist(IWhitelist _whitelist) external {
+        whitelist = _whitelist;
     }
 }

--- a/test/mock/MockSwapFacility.sol
+++ b/test/mock/MockSwapFacility.sol
@@ -13,6 +13,7 @@ pragma solidity 0.8.19;
 import {IMockSwapFacility} from "./interfaces/IMockSwapFacility.sol";
 
 import {MockERC20} from "./MockERC20.sol";
+import {MockOracle} from "./MockOracle.sol";
 import {ISwapRecipient} from "src/interfaces/ISwapRecipient.sol";
 
 contract MockSwapFacility is IMockSwapFacility {
@@ -22,6 +23,8 @@ contract MockSwapFacility is IMockSwapFacility {
 
     MockERC20 public immutable token0;
     MockERC20 public immutable token1;
+    address public immutable underlyingTokenOracle;
+    address public immutable billyTokenOracle;
 
     uint256 public exchangeRate;
 
@@ -33,9 +36,16 @@ contract MockSwapFacility is IMockSwapFacility {
 
     PendingSwap[] public pendingSwaps;
 
-    constructor(MockERC20 token0_, MockERC20 token1_) {
+    constructor(
+        MockERC20 token0_,
+        MockERC20 token1_,
+        MockOracle oracle1_,
+        MockOracle oracle2_
+    ) {
         token0 = token0_;
         token1 = token1_;
+        underlyingTokenOracle = address(oracle1_);
+        billyTokenOracle = address(oracle2_);
     }
 
     function setRate(uint256 newRate) external {


### PR DESCRIPTION
This PR adds changes to the `BloomPool` for the `EmergencyHandler`. Currently `emergencyHandler` is set as an address which has permissions to execute the emergency withdraw feature of `BloomPool`. This update enhances this by adding a contract called `EmergencyHandler` that will now be set as the `emergencyHandler` of a `BloomPool`. This addition will allow anyone to call `emergencyWithdraw` during  the `EmergencyExit` state which automatically sends all underlying tokens and bill tokens to the `EmergencyHandler` contract. This contract will hold all funds where users, both borrowers and lenders, can redeem their respective tokens at the rate during which `emergencyWithdraw` was executed at. This feature also introduces an `executeEmergencyBurn` function to coordinate in this effort.