### PR TITLE
Switch deployer to multisig for owners

### DIFF
--- a/script/deploy.main.sol
+++ b/script/deploy.main.sol
@@ -30,8 +30,8 @@ import {IRegistry} from "../src/interfaces/IRegistry.sol";
 
 
 contract Deploy is Test, Script {
-    address internal constant DEPLOYER = 0x91797a79fEA044D165B00D236488A0f2D22157BC;
-    address internal constant MULTISIG = address(0);
+    address internal constant DEPLOYER = 0x21c2bd51f230D69787DAf230672F70bAA1826F67;
+    address internal constant MULTISIG = 0x91797a79fEA044D165B00D236488A0f2D22157BC;
     address internal constant TREASURY = 0xFdC004B6B92b45B224d37dc45dBA5cA82c1e08f2;
     // Replace with real address if we arent deploying a new factory or registry
     address internal constant BLOOM_FACTORY_ADDRESS = address(0);

--- a/script/deploy.main.sol
+++ b/script/deploy.main.sol
@@ -227,7 +227,7 @@ contract Deploy is Test, Script {
         if (DEPLOY_EXCHANGE_RATE_REGISTRY) {
             address factoryAddress = DEPLOY_FACTORY ? address(bloomFactory) : BLOOM_FACTORY_ADDRESS;
 
-            ExchangeRateRegistry registry = new ExchangeRateRegistry(DEPLOYER, factoryAddress);
+            ExchangeRateRegistry registry = new ExchangeRateRegistry(MULTISIG, factoryAddress);
             vm.label(address(registry), "ExchangeRateRegistry");
             console2.log("ExchangeRateRegistry deployed at: ", address(registry));
             return registry;

--- a/script/deploy.main.sol
+++ b/script/deploy.main.sol
@@ -89,7 +89,7 @@ contract Deploy is Test, Script {
         // Deploy proxy for emergency handler
         TransparentUpgradeableProxy emergencyHandlerProxy = new TransparentUpgradeableProxy(
             address(emergencyHandlerImplementation),
-            DEPLOYER,
+            MULTISIG,
             ""
         );
 

--- a/script/deploy.main.test.sol
+++ b/script/deploy.main.test.sol
@@ -186,7 +186,7 @@ contract Deploy is Test, Script {
         if (DEPLOY_EXCHANGE_RATE_REGISTRY) {
             address factoryAddress = DEPLOY_FACTORY ? address(bloomFactory) : BLOOM_FACTORY_ADDRESS;
 
-            ExchangeRateRegistry registry = new ExchangeRateRegistry(DEPLOYER, factoryAddress);
+            ExchangeRateRegistry registry = new ExchangeRateRegistry(MULTISIG, factoryAddress);
             vm.label(address(registry), "ExchangeRateRegistry");
             console2.log("ExchangeRateRegistry deployed at: ", address(registry));
             return registry;

--- a/script/deploy.main.test.sol
+++ b/script/deploy.main.test.sol
@@ -89,7 +89,7 @@ contract Deploy is Test, Script {
         // Deploy proxy for emergency handler
         TransparentUpgradeableProxy emergencyHandlerProxy = new TransparentUpgradeableProxy(
             address(emergencyHandlerImplementation),
-            DEPLOYER,
+            MULTISIG,
             ""
         );
 

--- a/script/deploy.main.test.sol
+++ b/script/deploy.main.test.sol
@@ -31,7 +31,7 @@ import {IRegistry} from "../src/interfaces/IRegistry.sol";
 
 contract Deploy is Test, Script {
     address internal constant DEPLOYER = 0x91797a79fEA044D165B00D236488A0f2D22157BC;
-    address internal constant MULTISIG = address(0);
+    address internal constant MULTISIG = 0x91797a79fEA044D165B00D236488A0f2D22157BC;
     address internal constant TREASURY = 0xFdC004B6B92b45B224d37dc45dBA5cA82c1e08f2;
     // Replace with real address if we arent deploying a new factory or registry
     address internal constant BLOOM_FACTORY_ADDRESS = address(0);

--- a/script/deploy.main.test.sol
+++ b/script/deploy.main.test.sol
@@ -30,7 +30,7 @@ import {IRegistry} from "../src/interfaces/IRegistry.sol";
 
 
 contract Deploy is Test, Script {
-    address internal constant DEPLOYER = 0x91797a79fEA044D165B00D236488A0f2D22157BC;
+    address internal constant DEPLOYER = 0x21c2bd51f230D69787DAf230672F70bAA1826F67;
     address internal constant MULTISIG = 0x91797a79fEA044D165B00D236488A0f2D22157BC;
     address internal constant TREASURY = 0xFdC004B6B92b45B224d37dc45dBA5cA82c1e08f2;
     // Replace with real address if we arent deploying a new factory or registry

--- a/script/deploy.sepolia.sol
+++ b/script/deploy.sepolia.sol
@@ -30,7 +30,7 @@ import {IRegistry} from "../src/interfaces/IRegistry.sol";
 
 
 contract Deploy is Test, Script {
-    address internal constant DEPLOYER = 0x263c0a1ff85604f0ee3f4160cAa445d0bad28dF7;
+    address internal constant DEPLOYER = 0x91797a79fEA044D165B00D236488A0f2D22157BC;
     address internal constant MULTISIG = address(0);
     address internal constant TREASURY = 0xE4D701c6E3bFbA3e50D1045A3cef4797b6165119;
     // Replace with real address if we arent deploying a new factory or registry
@@ -225,7 +225,7 @@ contract Deploy is Test, Script {
         if (DEPLOY_EXCHANGE_RATE_REGISTRY) {
             address factoryAddress = DEPLOY_FACTORY ? address(bloomFactory) : BLOOM_FACTORY_ADDRESS;
 
-            ExchangeRateRegistry registry = new ExchangeRateRegistry(MULTISIG, factoryAddress);
+            ExchangeRateRegistry registry = new ExchangeRateRegistry(DEPLOYER, factoryAddress);
             vm.label(address(registry), "ExchangeRateRegistry");
             console2.log("ExchangeRateRegistry deployed at: ", address(registry));
             return registry;

--- a/script/deploy.sepolia.sol
+++ b/script/deploy.sepolia.sol
@@ -30,8 +30,7 @@ import {IRegistry} from "../src/interfaces/IRegistry.sol";
 
 
 contract Deploy is Test, Script {
-    address internal constant DEPLOYER = 0x91797a79fEA044D165B00D236488A0f2D22157BC;
-    address internal constant MULTISIG = address(0);
+    address internal constant DEPLOYER = 0x3031303BB07C35d489cd4B7E6cCd6Fb16eA2b3a1;
     address internal constant TREASURY = 0xE4D701c6E3bFbA3e50D1045A3cef4797b6165119;
     // Replace with real address if we arent deploying a new factory or registry
     address internal constant BLOOM_FACTORY_ADDRESS = address(0);
@@ -138,7 +137,7 @@ contract Deploy is Test, Script {
         vm.label(address(swap), "SwapFacility");
         console2.log("SwapFacility deployed at:", address(swap));
 
-        factory.transferOwnership(MULTISIG);
+        factory.transferOwnership(DEPLOYER);
         vm.stopBroadcast();
     }
 

--- a/script/deploy.sepolia.sol
+++ b/script/deploy.sepolia.sol
@@ -30,7 +30,7 @@ import {IRegistry} from "../src/interfaces/IRegistry.sol";
 
 
 contract Deploy is Test, Script {
-    address internal constant DEPLOYER = 0x91797a79fEA044D165B00D236488A0f2D22157BC;
+    address internal constant DEPLOYER = 0x263c0a1ff85604f0ee3f4160cAa445d0bad28dF7;
     address internal constant MULTISIG = address(0);
     address internal constant TREASURY = 0xE4D701c6E3bFbA3e50D1045A3cef4797b6165119;
     // Replace with real address if we arent deploying a new factory or registry
@@ -225,7 +225,7 @@ contract Deploy is Test, Script {
         if (DEPLOY_EXCHANGE_RATE_REGISTRY) {
             address factoryAddress = DEPLOY_FACTORY ? address(bloomFactory) : BLOOM_FACTORY_ADDRESS;
 
-            ExchangeRateRegistry registry = new ExchangeRateRegistry(DEPLOYER, factoryAddress);
+            ExchangeRateRegistry registry = new ExchangeRateRegistry(MULTISIG, factoryAddress);
             vm.label(address(registry), "ExchangeRateRegistry");
             console2.log("ExchangeRateRegistry deployed at: ", address(registry));
             return registry;

--- a/script/deploy.sepolia.sol
+++ b/script/deploy.sepolia.sol
@@ -30,7 +30,7 @@ import {IRegistry} from "../src/interfaces/IRegistry.sol";
 
 
 contract Deploy is Test, Script {
-    address internal constant DEPLOYER = 0x3031303BB07C35d489cd4B7E6cCd6Fb16eA2b3a1;
+    address internal constant DEPLOYER = 0x263c0a1ff85604f0ee3f4160cAa445d0bad28dF7;
     address internal constant TREASURY = 0xE4D701c6E3bFbA3e50D1045A3cef4797b6165119;
     // Replace with real address if we arent deploying a new factory or registry
     address internal constant BLOOM_FACTORY_ADDRESS = address(0);


### PR DESCRIPTION
This PR updates the deployment script with a new variable `MULTISIG` and switches the current ExchangeRateRegistry owner inputs from `DEPLOYER` to `MULTISIG`.