### PR TITLE
Stusd upgrades

### DIFF
--- a/script/deploy.main.sol
+++ b/script/deploy.main.sol
@@ -32,7 +32,7 @@ import {IRegistry} from "../src/interfaces/IRegistry.sol";
 contract Deploy is Test, Script {
     address internal constant DEPLOYER = 0x21c2bd51f230D69787DAf230672F70bAA1826F67;
     address internal constant MULTISIG = 0x91797a79fEA044D165B00D236488A0f2D22157BC;
-    address internal constant TREASURY = 0xFdC004B6B92b45B224d37dc45dBA5cA82c1e08f2;
+    // address internal constant TREASURY = 0xFdC004B6B92b45B224d37dc45dBA5cA82c1e08f2;
     // Replace with real address if we arent deploying a new factory or registry
     address internal constant BLOOM_FACTORY_ADDRESS = address(0);
     address internal constant EXCHANGE_RATE_REGISTRY = address(0);
@@ -94,7 +94,6 @@ contract Deploy is Test, Script {
         );
 
         IBloomFactory.PoolParams memory poolParams = IBloomFactory.PoolParams(
-            TREASURY,
             address(WHITELIST_BORROW),
             address(LENDER_RETURN_BPS_FEED),
             address(emergencyHandlerProxy),
@@ -102,9 +101,7 @@ contract Deploy is Test, Script {
             10.0e6,
             commitPhaseDuration,
             swapTimeout,
-            poolPhaseDuration,
-            0, // 0%
-            0 // 0%
+            poolPhaseDuration
         );
 
         IBloomFactory.SwapFacilityParams memory swapFacilityParams = IBloomFactory.SwapFacilityParams(

--- a/script/deploy.main.test.sol
+++ b/script/deploy.main.test.sol
@@ -32,7 +32,7 @@ import {IRegistry} from "../src/interfaces/IRegistry.sol";
 contract Deploy is Test, Script {
     address internal constant DEPLOYER = 0x21c2bd51f230D69787DAf230672F70bAA1826F67;
     address internal constant MULTISIG = 0x91797a79fEA044D165B00D236488A0f2D22157BC;
-    address internal constant TREASURY = 0xFdC004B6B92b45B224d37dc45dBA5cA82c1e08f2;
+    // address internal constant TREASURY = 0xFdC004B6B92b45B224d37dc45dBA5cA82c1e08f2;
     // Replace with real address if we arent deploying a new factory or registry
     address internal constant BLOOM_FACTORY_ADDRESS = address(0);
     address internal constant EXCHANGE_RATE_REGISTRY = address(0);
@@ -94,7 +94,6 @@ contract Deploy is Test, Script {
         );
 
         IBloomFactory.PoolParams memory poolParams = IBloomFactory.PoolParams(
-            TREASURY,
             address(WHITELIST_BORROW),
             address(LENDER_RETURN_BPS_FEED),
             address(emergencyHandlerProxy),
@@ -102,9 +101,7 @@ contract Deploy is Test, Script {
             10.0e6,
             commitPhaseDuration,
             swapTimeout,
-            poolPhaseDuration,
-            0, // 0%
-            0 // 0%
+            poolPhaseDuration
         );
 
         IBloomFactory.SwapFacilityParams memory swapFacilityParams = IBloomFactory.SwapFacilityParams(

--- a/script/deploy.sepolia.sol
+++ b/script/deploy.sepolia.sol
@@ -31,7 +31,7 @@ import {IRegistry} from "../src/interfaces/IRegistry.sol";
 
 contract Deploy is Test, Script {
     address internal constant DEPLOYER = 0x263c0a1ff85604f0ee3f4160cAa445d0bad28dF7;
-    address internal constant TREASURY = 0xE4D701c6E3bFbA3e50D1045A3cef4797b6165119;
+    // address internal constant TREASURY = 0xE4D701c6E3bFbA3e50D1045A3cef4797b6165119;
     // Replace with real address if we arent deploying a new factory or registry
     address internal constant BLOOM_FACTORY_ADDRESS = address(0);
     address internal constant EXCHANGE_RATE_REGISTRY = address(0);
@@ -99,7 +99,6 @@ contract Deploy is Test, Script {
         );
 
         IBloomFactory.PoolParams memory poolParams = IBloomFactory.PoolParams(
-            TREASURY,
             address(WHITELIST),
             address(BPSFEED),
             address(emergencyHandlerProxy),
@@ -107,9 +106,7 @@ contract Deploy is Test, Script {
             10.0e6,
             commitPhaseDuration,
             swapTimeout,
-            poolPhaseDuration,
-            0, // 0%
-            0 // 0%
+            poolPhaseDuration
         );
 
         IBloomFactory.SwapFacilityParams memory swapFacilityParams = IBloomFactory.SwapFacilityParams(

--- a/src/BloomFactory.sol
+++ b/src/BloomFactory.sol
@@ -75,7 +75,6 @@ contract BloomFactory is IBloomFactory, Ownable2Step {
             billToken,
             IWhitelist(poolParams.borrowerWhiteList),
             address(swapFacility),
-            poolParams.treasury,
             poolParams.lenderReturnBpsFeed,
             poolParams.emergencyHandler,
             poolParams.leverageBps,
@@ -83,8 +82,6 @@ contract BloomFactory is IBloomFactory, Ownable2Step {
             poolParams.commitPhaseDuration,
             poolParams.swapTimeout,
             poolParams.poolPhaseDuration,
-            poolParams.lenderReturnFee,
-            poolParams.borrowerReturnFee,
             name,
             symbol
         );

--- a/src/BloomPool.sol
+++ b/src/BloomPool.sol
@@ -217,7 +217,6 @@ contract BloomPool is IBloomPool, ISwapRecipient, ERC20 {
 
             uint256 borrowerReturn = outAmount - lenderReturn;
 
-
             borrowerDistribution = borrowerReturn.toUint128();
             totalBorrowerShares = uint256(totalMatched * BPS / LEVERAGE_BPS).toUint128();
 

--- a/src/helpers/ExchangeRateRegistry.sol
+++ b/src/helpers/ExchangeRateRegistry.sol
@@ -211,7 +211,7 @@ contract ExchangeRateRegistry is IRegistry, Ownable2Step {
             timeElapsed = duration;
         }
         
-        uint256 delta = (rate * BASE_RATE  * timeElapsed) / 
+        uint256 delta = (rate * BASE_RATE * timeElapsed) / 
             ONE_YEAR / 1e18;
 
         return BASE_RATE + delta;

--- a/src/helpers/ExchangeRateRegistry.sol
+++ b/src/helpers/ExchangeRateRegistry.sol
@@ -210,9 +210,8 @@ contract ExchangeRateRegistry is IRegistry, Ownable2Step {
         if (timeElapsed > duration) {
             timeElapsed = duration;
         }
-        uint256 adjustedLenderFee = pool.LENDER_RETURN_FEE() * SCALER;
         
-        uint256 delta = ((rate * (BASE_RATE - adjustedLenderFee)) * timeElapsed) / 
+        uint256 delta = ((rate * BASE_RATE ) * timeElapsed) / 
             ONE_YEAR / 1e18;
 
         return BASE_RATE + delta;

--- a/src/helpers/ExchangeRateRegistry.sol
+++ b/src/helpers/ExchangeRateRegistry.sol
@@ -211,7 +211,7 @@ contract ExchangeRateRegistry is IRegistry, Ownable2Step {
             timeElapsed = duration;
         }
         
-        uint256 delta = ((rate * BASE_RATE ) * timeElapsed) / 
+        uint256 delta = (rate * BASE_RATE  * timeElapsed) / 
             ONE_YEAR / 1e18;
 
         return BASE_RATE + delta;

--- a/src/interfaces/IBloomFactory.sol
+++ b/src/interfaces/IBloomFactory.sol
@@ -8,7 +8,7 @@
 ╚═════╝░╚══════╝░╚════╝░░╚════╝░╚═╝░░░░░╚═╝
 */
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.19;
 
 import {BloomPool} from "../BloomPool.sol";
 
@@ -19,7 +19,6 @@ interface IBloomFactory {
     error InvalidPoolAddress();
 
     struct PoolParams {
-        address treasury;
         address borrowerWhiteList;
         address lenderReturnBpsFeed;
         address emergencyHandler;
@@ -28,8 +27,6 @@ interface IBloomFactory {
         uint256 commitPhaseDuration;
         uint256 swapTimeout;
         uint256 poolPhaseDuration;
-        uint256 lenderReturnFee;
-        uint256 borrowerReturnFee;
     }
 
     struct SwapFacilityParams {

--- a/src/interfaces/IBloomFactory.sol
+++ b/src/interfaces/IBloomFactory.sol
@@ -38,6 +38,7 @@ interface IBloomFactory {
         uint256 maxBillyValue;
     }
 
+    event NewStUSD(address stUSD);
     event NewBloomPoolCreated(address indexed pool, address swapFacility);
 
     /**
@@ -46,11 +47,22 @@ interface IBloomFactory {
     function getLastCreatedPool() external view returns (address);
 
     /**
+     * @notice Returns the address of the StUSD token
+     */
+    function getStUSD() external view returns (address);
+
+    /**
      * @notice Returns true if the pool was created from the factory
      * @param pool Address of a BloomPool
      * @return True if the pool was created from the factory
      */
     function isPoolFromFactory(address pool) external view returns (bool);
+
+    /**
+     * @notice Sets the address of the StUSD token
+     * @param stUSD Address of the StUSD token
+     */
+    function setStUSD(address stUSD) external;
 
     /**
      * @notice Create and initializes a new BloomPool and SwapFacility

--- a/src/interfaces/IBloomPool.sol
+++ b/src/interfaces/IBloomPool.sol
@@ -122,7 +122,6 @@ interface IBloomPool {
     function BILL_TOKEN() external view returns (address);
     function WHITELIST() external view returns (IWhitelist);
     function SWAP_FACILITY() external view returns (address);
-    function TREASURY() external view returns (address);
     function LENDER_RETURN_BPS_FEED() external view returns (address);
     function LEVERAGE_BPS() external view returns (uint256);
     function MIN_BORROW_DEPOSIT() external view returns (uint256);
@@ -131,8 +130,6 @@ interface IBloomPool {
     function POST_HOLD_SWAP_TIMEOUT_END() external view returns (uint256);
     function POOL_PHASE_END() external view returns (uint256);
     function POOL_PHASE_DURATION() external view returns (uint256);
-    function LENDER_RETURN_FEE() external view returns (uint256);
-    function BORROWER_RETURN_FEE() external view returns (uint256);
 
     function state() external view returns (State currentState);
     function totalMatchAmount() external view returns (uint256);

--- a/src/interfaces/IEmergencyHandler.sol
+++ b/src/interfaces/IEmergencyHandler.sol
@@ -8,7 +8,7 @@
 ╚═════╝░╚══════╝░╚════╝░░╚════╝░╚═╝░░░░░╚═╝
 */
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.19;
 
 import {IBloomPool} from "./IBloomPool.sol";
 import {IOracle} from "./IOracle.sol";

--- a/src/interfaces/IRegistry.sol
+++ b/src/interfaces/IRegistry.sol
@@ -8,7 +8,7 @@
 ╚═════╝░╚══════╝░╚════╝░░╚════╝░╚═╝░░░░░╚═╝
 */
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.19;
 
 import {IBloomPool} from "./IBloomPool.sol";
 

--- a/src/interfaces/IStUSD.sol
+++ b/src/interfaces/IStUSD.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+interface IStUSD {
+
+    /**
+     * @notice Invokes the auto stake feature or adjusts the remaining balance
+     * if the most recent deposit did not get fully staked
+     * @dev autoMint feature is invoked if the last created pool is in
+     * the commit state
+     * @dev remainingBalance adjustment is invoked if the last created pool is
+     * in any other state than commit and deposits dont get fully staked
+     * @dev anyone can call this function for now
+     */
+    function poke() external;
+}

--- a/src/interfaces/ISwapRecipient.sol
+++ b/src/interfaces/ISwapRecipient.sol
@@ -8,7 +8,7 @@
 ╚═════╝░╚══════╝░╚════╝░░╚════╝░╚═╝░░░░░╚═╝
 */
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.19;
 
 interface ISwapRecipient {
     /**

--- a/test/BloomFactory.t.sol
+++ b/test/BloomFactory.t.sol
@@ -47,7 +47,6 @@ contract BloomFactoryTest is Test {
         billOracle = new MockOracle(8);
 
         poolParams = IBloomFactory.PoolParams({
-            treasury: address(1), // Set to address(1) b/c irrelevant for tests
             borrowerWhiteList: address(2),  // Set to address(2) b/c irrelevant for tests
             lenderReturnBpsFeed: address(3), // Set to address(3) b/c irrelevant for tests
             emergencyHandler: address(4), // Set to address(4) b/c irrelevant for tests
@@ -55,9 +54,7 @@ contract BloomFactoryTest is Test {
             minBorrowDeposit: 100e18,
             commitPhaseDuration: 3 days,
             swapTimeout: 7 days,
-            poolPhaseDuration: 180 days,
-            lenderReturnFee: 1000,
-            borrowerReturnFee: 300
+            poolPhaseDuration: 180 days
         });
 
         swapFacilityParams = IBloomFactory.SwapFacilityParams({

--- a/test/BloomPool.t.sol
+++ b/test/BloomPool.t.sol
@@ -38,7 +38,6 @@ contract BloomPoolTest is Test {
     MockOracle internal billOracle;
     MockBPSFeed internal feed;
 
-    address internal treasury = makeAddr("treasury");
     address internal multisig = makeAddr("multisig");
     address internal factory = makeAddr("factory");
     
@@ -84,7 +83,6 @@ contract BloomPoolTest is Test {
             billToken: address(billyToken),
             whitelist: IWhitelist(address(whitelist)),
             swapFacility: address(swap),
-            treasury: treasury,
             leverageBps: 4 * BPS,
             emergencyHandler: address(emergencyHandler),
             minBorrowDeposit: 100.0e6,
@@ -92,8 +90,6 @@ contract BloomPoolTest is Test {
             swapTimeout: 7 days,
             poolPhaseDuration: poolPhaseDuration = 180 days,
             lenderReturnBpsFeed: address(feed),
-            lenderReturnFee: 0,
-            borrowerReturnFee: 0,
             name: "Term Bound Token 6 month 2023-06-1",
             symbol: "TBT-1"
         });
@@ -413,17 +409,11 @@ contract BloomPoolTest is Test {
             lenderReceived = (totalMatchAmount + yield);
             borrowerReceived = totalAmount - lenderReceived;
 
-            uint256 lenderFee = (lenderReceived - totalMatchAmount) * pool.LENDER_RETURN_FEE() / BPS;
-            uint256 borrowerFee = borrowerReceived * pool.BORROWER_RETURN_FEE() / BPS;
-
-            lenderReceived -= lenderFee;
-            borrowerReceived -= borrowerFee;
             totalAmount = lenderReceived + borrowerReceived;
 
             assertEq(lenderDist, lenderReceived);
             assertEq(borrowerDist, borrowerReceived);
 
-            assertEq(stableToken.balanceOf(treasury), lenderFee + borrowerFee);
         }
 
         // Lender Withdraw

--- a/test/ExchangeRateRegistry.t.sol
+++ b/test/ExchangeRateRegistry.t.sol
@@ -34,7 +34,6 @@ contract ExchangeRateRegistryTest is Test {
     MockOracle internal oracle1;
     MockOracle internal oracle2;
 
-    address internal treasury = makeAddr("treasury");
     address internal registryOwner = makeAddr("owner");
     address internal factory = makeAddr("factory");
 
@@ -43,7 +42,6 @@ contract ExchangeRateRegistryTest is Test {
 
     uint256 internal constant ORACLE_RATE = 1.5e4;
     uint256 internal constant BPS = 1e4;
-    uint256 internal constant LENDER_RETURN_FEE = 1000;
     uint256 internal constant SCALER = 1e14;
     uint256 internal constant COMMIT_PHASE = 3 days;
     uint256 internal constant POOL_DURATION = 360 days;
@@ -72,7 +70,6 @@ contract ExchangeRateRegistryTest is Test {
             billToken: address(billyToken),
             whitelist: IWhitelist(address(whitelist)),
             swapFacility: address(swap),
-            treasury: treasury,
             leverageBps: 4 * BPS,
             emergencyHandler: address(0),
             minBorrowDeposit: 100e18,
@@ -80,8 +77,6 @@ contract ExchangeRateRegistryTest is Test {
             swapTimeout: 7 days,
             poolPhaseDuration: POOL_DURATION,
             lenderReturnBpsFeed: address(feed),
-            lenderReturnFee: LENDER_RETURN_FEE,
-            borrowerReturnFee: 3000,
             name: "Term Bound Token 6 month 2023-06-1",
             symbol: "TBT-1"
         });
@@ -107,7 +102,7 @@ contract ExchangeRateRegistryTest is Test {
             skip(timePerInterval);
             
             uint256 valueAccrued = (((ORACLE_RATE - 1e4) * SCALER) / testingIntervals) * i;
-            uint256 lenderShare = valueAccrued * (LENDER_RETURN_FEE * SCALER) / 1e18;
+            uint256 lenderShare = valueAccrued / 1e18;
             uint256 expectedRate = STARTING_EXCHANGE_RATE + valueAccrued - lenderShare;
 
             assertEq(registry.getExchangeRate(address(pool)), expectedRate);


### PR DESCRIPTION
# Description

<!-- Describe the changes introduced in this pull request. -->
This PR addresses changes that were brought up in the audit of stUSD (stTBY) [H-08] Deposits of current TBY to stUSD immediately before a new TBY is deployed will cause double counting. To alleviate this issue the function `poke()` from stUSD has been introduced into the factory contract, such that it's called before deploying a new `BloomPool` to ensure that the values are up-to-date and avoid any double counting. In addition to that `lenderReturnFee`, `borrowerReturnFee` & `Treasury` have been removed from `BloomPools` as the first two have always been set to zero and are not necessary to the functionality as a result `Treasury` no longer needs to be included. Finally, the `BloomPoolFactory` has been made to be upgradeable so that there is no need to ever deploy another Factory contract besides a new implementation. This allows for the `BloomPool` instances to remain immutable by nature and future `BloomPool`s instances can be enhanced as needed.
<!-- Include any context necessary for understanding the PR's purpose. -->


## Type of change

- [X] Audit fix <!-- (non-breaking change which addresses an audit item) -->
- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [X] Complex code has been commented, including external interfaces
- [X] Tests are included for all code paths
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
stUSD / stTBY audit by 0x52 issue [H-08]