### PR TITLE
Support EmergencyExit mode within ExchangeRateRegistry

### DIFF
--- a/src/interfaces/IBloomFactory.sol
+++ b/src/interfaces/IBloomFactory.sol
@@ -38,7 +38,7 @@ interface IBloomFactory {
         uint256 maxBillyValue;
     }
 
-    event NewStUSD(address stUSD);
+    event StTBYSet(address stTBY);
     event NewBloomPoolCreated(address indexed pool, address swapFacility);
 
     /**
@@ -47,9 +47,9 @@ interface IBloomFactory {
     function getLastCreatedPool() external view returns (address);
 
     /**
-     * @notice Returns the address of the StUSD token
+     * @notice Returns the address of the StTBY token
      */
-    function getStUSD() external view returns (address);
+    function getStTBY() external view returns (address);
 
     /**
      * @notice Returns true if the pool was created from the factory
@@ -59,10 +59,10 @@ interface IBloomFactory {
     function isPoolFromFactory(address pool) external view returns (bool);
 
     /**
-     * @notice Sets the address of the StUSD token
-     * @param stUSD Address of the StUSD token
+     * @notice Sets the address of the StTBY token
+     * @param stTBY Address of the StTBY token
      */
-    function setStUSD(address stUSD) external;
+    function setStTBY(address stTBY) external;
 
     /**
      * @notice Create and initializes a new BloomPool and SwapFacility

--- a/src/interfaces/IEmergencyHandler.sol
+++ b/src/interfaces/IEmergencyHandler.sol
@@ -55,7 +55,7 @@ interface IEmergencyHandler {
      * @param _pool BloomPool that the funds in the emergency handler contract orginated from
      * @return amount of underlying assets redeemed
      */
-    function redeem(IBloomPool _pool) external returns (uint256);
+    function redeemLender(IBloomPool _pool) external returns (uint256);
 
     /**
      * @notice  Redeem underlying assets for borrowers of a BloomPool in Emergency Exit mode
@@ -63,7 +63,7 @@ interface IEmergencyHandler {
      * @param id Id of the borrowers commit in the corresponding BloomPool
      * @return amount of underlying assets redeemed
      */
-    function redeem(IBloomPool pool, uint256 id) external returns (uint256);
+    function redeemBorrower(IBloomPool pool, uint256 id) external returns (uint256);
 
     /**
      * @notice Allows Market Makers to swap underlying assets for bill tokens

--- a/src/interfaces/IRegistry.sol
+++ b/src/interfaces/IRegistry.sol
@@ -28,6 +28,13 @@ interface IRegistry {
      * @dev This is a permissioned function. Only the BloomFactory or the registry owner can call this function
      * @param token The TBY token that will be registered (aka the BloomPool)
      */
-    function registerToken(IBloomPool token) external; 
+    function registerToken(IBloomPool token) external;
 
+    /**
+     * @notice Set the exchange rate for a token that is in emergency mode
+     * @dev Bool pool's stop accruing interest in the event that the pool goes into emergency exit mode
+     * @dev This is a permissioned function. Only the BloomPool itself can call.
+     * @param rate The exchange rate at the time of emergency exit mode.
+     */
+    function setEmergencyRate(uint256 rate) external;
 }

--- a/src/interfaces/IStTBY.sol
+++ b/src/interfaces/IStTBY.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.23;
-interface IStUSD {
 
+// TODO: Update to handle any LayerZero changes.
+interface IStTBY {
     /**
      * @notice Invokes the auto stake feature or adjusts the remaining balance
      * if the most recent deposit did not get fully staked

--- a/src/interfaces/IStTBY.sol
+++ b/src/interfaces/IStTBY.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.23;
 
-// TODO: Update to handle any LayerZero changes.
 interface IStTBY {
     /**
      * @notice Invokes the auto stake feature or adjusts the remaining balance

--- a/test/BloomFactory.t.sol
+++ b/test/BloomFactory.t.sol
@@ -101,10 +101,10 @@ contract BloomFactoryTest is Test {
         BloomPool pool = _newPoolInstance();
 
         // Verfiy that the the factory registers and activates the token on deployment
-        (bool isRegistered, bool isActive, ) = registry.tokenInfos(address(pool));
+        (bool isRegistered, bool isActive, bool emergency, ) = registry.tokenInfos(address(pool));
         assertEq(isRegistered, true);
         assertEq(isActive, true);
-
+        assertEq(emergency, false);
     }
 
     function _newPoolInstance() private returns (BloomPool) {

--- a/test/BloomPool.t.sol
+++ b/test/BloomPool.t.sol
@@ -86,6 +86,7 @@ contract BloomPoolTest is Test {
             underlyingToken: address(stableToken),
             billToken: address(billyToken),
             whitelist: IWhitelist(address(whitelist)),
+            exchangeRateRegistry: registry,
             swapFacility: address(swap),
             leverageBps: 4 * BPS,
             emergencyHandler: address(emergencyHandler),

--- a/test/ExchangeRateRegistry.t.sol
+++ b/test/ExchangeRateRegistry.t.sol
@@ -65,10 +65,13 @@ contract ExchangeRateRegistryTest is Test {
 
         feed.setRate(ORACLE_RATE);
 
+        registry = new ExchangeRateRegistry(registryOwner, factory);
+
         pool = new BloomPool({
             underlyingToken: address(stableToken),
             billToken: address(billyToken),
             whitelist: IWhitelist(address(whitelist)),
+            exchangeRateRegistry: registry,
             swapFacility: address(swap),
             leverageBps: 4 * BPS,
             emergencyHandler: address(0),
@@ -80,8 +83,6 @@ contract ExchangeRateRegistryTest is Test {
             name: "Term Bound Token 6 month 2023-06-1",
             symbol: "TBT-1"
         });
-
-        registry = new ExchangeRateRegistry(registryOwner, factory);
     }
 
     function test_RegistryOwner() public {
@@ -125,5 +126,10 @@ contract ExchangeRateRegistryTest is Test {
         
         vm.prank(registryOwner);
         registry.updateBloomFactory(newFactory);
+    }
+
+    function test_NonePoolEmergency() public {
+        vm.expectRevert(ExchangeRateRegistry.InvalidUser.selector);
+        registry.setEmergencyRate(1.1e18);
     }
 }


### PR DESCRIPTION
In order to provide better support for the composability of Bloom Pools the `ExchangeRateRegistry` needs to support the ability to freeze exchange rates in the event that a pool enters `EmergencyExit` mode. This PR makes these changes as well as some auxiliary updates outlined below.

Changes Made:
- Within the `BloomFactory`  `stUSD` was renamed to `stTBY`.
- `ExchangeRateRegistry::setEmergencyRate` was added to allow for the `BloomPool` to call this function during `EmergencyExit` mode.
    - Sets the rate to `1e18` in the event that no yield has been accrued.
- Tests added to test this functionality 
- `exchangeRateRegistry` added to the params on Bloom Pools to allow `setEmergencyRate` to be called.
- `EmergencyHandler::redeem` has been renamed to `redeemLender` and `redeemBorrower` to decrease confusing and to conform with industry standards.